### PR TITLE
request header object cannot be passed into Map directly.

### DIFF
--- a/src/ui/account.js
+++ b/src/ui/account.js
@@ -219,11 +219,7 @@ cwc.ui.Account.prototype.request = function(opts, callback) {
     }
   }
 
-
-  let headers = new Map();
-  for(let headerKey in opts.header) {
-    headers.set(headerKey, opts.header[headerKey]);
-  }
+  let headers = new Map(Object.entries(opts.header || {}));
   headers.set('Authorization', 'Bearer ' + token);
   headers.set('X-JavaScript-User-Agent', 'Coding with Chrome');
 

--- a/src/ui/account.js
+++ b/src/ui/account.js
@@ -219,7 +219,11 @@ cwc.ui.Account.prototype.request = function(opts, callback) {
     }
   }
 
-  let headers = new Map(opts.header);
+
+  let headers = new Map();
+  for(let headerKey in opts.header) {
+    headers.set(headerKey, opts.header[headerKey]);
+  }
   headers.set('Authorization', 'Bearer ' + token);
   headers.set('X-JavaScript-User-Agent', 'Coding with Chrome');
 


### PR DESCRIPTION
Account request function was changed from goog.struct.Map to a plain JS Map, but JS Maps do not accept an object in the constructor (https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Map).

Updated to not use a constructor parameter to copy over values from opts.header object.