### PR TITLE
Added handling for .js files

### DIFF
--- a/src/mode/javascript/editor.js
+++ b/src/mode/javascript/editor.js
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview Editor for the Javascript modification.
+ *
+ * @license Copyright 2015 The Coding with Chrome Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author carheden@google.com (Adam Carheden)
+ */
+goog.provide('cwc.mode.javascript.Editor');
+
+goog.require('cwc.ui.Editor');
+goog.require('cwc.utils.Helper');
+
+
+/**
+ * @constructor
+ * @param {!cwc.utils.Helper} helper
+ * @struct
+ * @final
+ */
+cwc.mode.javascript.Editor = function(helper) {
+  /** @type {!cwc.utils.Helper} */
+  this.helper = helper;
+
+  /** @type {!cwc.ui.Editor} */
+  this.editor = new cwc.ui.Editor(helper);
+};
+
+
+/**
+ * Decorates the text Editor.
+ */
+cwc.mode.javascript.Editor.prototype.decorate = function() {
+  this.helper.setInstance('editor', this.editor, true);
+  this.editor.decorate();
+  this.editor.showLibraryButton(false);
+  this.editor.showEditorViews(false);
+};

--- a/src/mode/javascript/layout.js
+++ b/src/mode/javascript/layout.js
@@ -1,0 +1,46 @@
+/**
+ * @fileoverview Layout for the Javascript modification.
+ *
+ * @license Copyright 2015 The Coding with Chrome Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author carheden@google.com (Adam Carheden)
+ */
+goog.provide('cwc.mode.javascript.Layout');
+
+goog.require('cwc.soy.mode.Javascript');
+
+
+/**
+ * @constructor
+ * @param {!cwc.utils.Helper} helper
+ */
+cwc.mode.javascript.Layout = function(helper) {
+  /** @type {!cwc.utils.Helper} */
+  this.helper = helper;
+
+  /** @type {string} */
+  this.prefix = helper.getPrefix();
+};
+
+
+/**
+ * Decorates the text layout.
+ */
+cwc.mode.javascript.Layout.prototype.decorate = function() {
+  let layoutInstance = this.helper.getInstance('layout', true);
+  layoutInstance.decorateDefault(500);
+  layoutInstance.renderMiddleContent(cwc.soy.mode.Javascript.editor);
+  layoutInstance.renderRightContent(cwc.soy.mode.Javascript.preview);
+};

--- a/src/mode/javascript/layout.soy
+++ b/src/mode/javascript/layout.soy
@@ -1,0 +1,38 @@
+/**
+ * @fileoverview Layout template for the text modification.
+ *
+ * @license Copyright 2015 The Coding with Chrome Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author carheden@google.com (Adam Carheden)
+ */
+{namespace cwc.soy.mode.Javascript autoescape="strict"}
+
+
+/**
+ * Layout template.
+ */
+{template .editor}
+  {@param prefix: string}
+  <div id="{$prefix}editor-chrome"></div>
+{/template}
+
+
+/**
+ * Preview template.
+ */
+{template .preview}
+  {@param prefix: string}
+  <div id="{$prefix}preview-chrome"></div>
+{/template}

--- a/src/mode/javascript/mod.js
+++ b/src/mode/javascript/mod.js
@@ -1,0 +1,55 @@
+/**
+ * @fileoverview Javascript modifications.
+ *
+ * @license Copyright 2015 The Coding with Chrome Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author carheden@google.com (Adam Carheden)
+ */
+goog.provide('cwc.mode.javascript.Mod');
+
+goog.require('cwc.mode.javascript.Editor');
+goog.require('cwc.mode.javascript.Layout');
+goog.require('cwc.mode.javascript.Preview');
+goog.require('cwc.renderer.internal.Javascript');
+
+
+/**
+ * @constructor
+ * @param {!cwc.utils.Helper} helper
+ */
+cwc.mode.javascript.Mod = function(helper) {
+  /** @type {cwc.mode.javascript.Layout} */
+  this.layout = new cwc.mode.javascript.Layout(helper);
+
+  /** @type {cwc.mode.javascript.Editor} */
+  this.editor = new cwc.mode.javascript.Editor(helper);
+
+  /** @type {cwc.mode.javascript.Preview} */
+  this.preview = new cwc.mode.javascript.Preview(helper);
+
+  /** @type {cwc.renderer.internal.Javascript} */
+  this.renderer = new cwc.renderer.internal.Javascript(helper);
+};
+
+
+/**
+ * Decorates the different parts of the modification.
+ */
+cwc.mode.javascript.Mod.prototype.decorate = function() {
+  this.layout.decorate();
+  this.editor.decorate();
+  this.preview.decorate();
+  this.renderer.init();
+};

--- a/src/mode/javascript/preview.js
+++ b/src/mode/javascript/preview.js
@@ -1,0 +1,49 @@
+/**
+ * @fileoverview Preview for the Javascript editor.
+ *
+ * @license Copyright 2015 The Coding with Chrome Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author carheden@google.com (Adam Carheden)
+ */
+
+goog.provide('cwc.mode.javascript.Preview');
+
+goog.require('cwc.ui.Preview');
+goog.require('cwc.utils.Helper');
+
+
+/**
+ * @constructor
+ * @param {!cwc.utils.Helper} helper
+ * @struct
+ * @final
+ */
+cwc.mode.javascript.Preview = function(helper) {
+  /** @type {!cwc.utils.Helper} */
+  this.helper = helper;
+
+  /** @type {!cwc.ui.Preview} */
+  this.preview = new cwc.ui.Preview(helper);
+};
+
+
+/**
+ * Decorates the preview window.
+ */
+cwc.mode.javascript.Preview.prototype.decorate = function() {
+  this.helper.setInstance('preview', this.preview, true);
+  this.preview.decorate();
+  this.preview.showConsole(true);
+};

--- a/src/mode/mode_config_data.js
+++ b/src/mode/mode_config_data.js
@@ -29,6 +29,7 @@ goog.require('cwc.mode.coffeescript.Mod');
 goog.require('cwc.mode.ev3.advanced.Mod');
 goog.require('cwc.mode.ev3.blockly.Mod');
 goog.require('cwc.mode.html5.Mod');
+goog.require('cwc.mode.javascript.Mod');
 goog.require('cwc.mode.json.Mod');
 goog.require('cwc.mode.makeblock.mbot.blockly.Mod');
 goog.require('cwc.mode.makeblock.mbotRanger.blockly.Mod');
@@ -121,7 +122,6 @@ cwc.mode.ConfigData[cwc.mode.Type.BASIC] = new cwc.mode.Mod({
   title: 'Simple',
 });
 
-
 /**
  * Basic blockly mode.
  */
@@ -136,6 +136,19 @@ cwc.mode.ConfigData[cwc.mode.Type.BASIC_BLOCKLY] = new cwc.mode.Mod({
   title: 'Blocks',
 });
 
+/**
+ * Javascript mode. (raw .js file without .cwc wrapper)
+ */
+cwc.mode.ConfigData[cwc.mode.Type.JAVASCRIPT] = new cwc.mode.Mod({
+  authors: ['Adam Carheden'],
+  auto_preview: true,
+  file_type: cwc.file.Type.JAVASCRIPT,
+  icon: 'local_cafe',
+  mime_types: [cwc.file.MimeType.JAVASCRIPT.type],
+  mod: cwc.mode.javascript.Mod,
+  name: 'Javascript',
+  title: 'JavaScript',
+});
 
 /**
  * Mindstorms EV3 advanced mode.

--- a/src/renderer/internal/javascript.js
+++ b/src/renderer/internal/javascript.js
@@ -1,0 +1,71 @@
+/**
+ * @fileoverview Renderer for Javascript modification.
+ *
+ * @license Copyright 2015 The Coding with Chrome Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author carheden@google.com (Adam Carheden)
+ */
+goog.provide('cwc.renderer.internal.Javascript');
+
+goog.require('cwc.ui.EditorContent');
+goog.require('cwc.file.Files');
+goog.require('cwc.framework.External');
+goog.require('cwc.renderer.Helper');
+goog.require('cwc.utils.Helper');
+
+
+/**
+ * @constructor
+ * @param {!cwc.utils.Helper} helper
+ * @struct
+ * @final
+ */
+cwc.renderer.internal.Javascript = function(helper) {
+  /** @type {!cwc.utils.Helper} */
+  this.helper = helper;
+};
+
+
+/**
+ * Initializes and defines the Javascript renderer.
+ */
+cwc.renderer.internal.Javascript.prototype.init = function() {
+  let rendererInstance = this.helper.getInstance('renderer', true);
+  let renderer = this.render.bind(this);
+  rendererInstance.setRenderer(renderer);
+};
+
+
+/**
+ * @param {Object} editor_content
+ * @param {Object} editor_flags
+ * @param {!cwc.file.Files} libraryFiles
+ * @param {!cwc.file.Files} frameworks
+ * @param {!cwc.file.Files} styleSheets
+ * @param {cwc.renderer.Helper} renderer_helper
+ * @return {!string}
+ * @export
+ */
+cwc.renderer.internal.Javascript.prototype.render = function(
+    editor_content,
+    editor_flags,
+    libraryFiles,
+    frameworks,
+    styleSheets,
+    renderer_helper) {
+  let body = '\n<script type="text/javascript">\n' +
+    editor_content[cwc.ui.EditorContent.DEFAULT] + '\n</script>\n';
+  return renderer_helper.getHTML(body, '');
+};

--- a/static_files/resources/examples/javascript/raw/countdown.js
+++ b/static_files/resources/examples/javascript/raw/countdown.js
@@ -1,0 +1,4 @@
+// Countdown Javascript
+let len = 10;
+let countdown = Array.from({length: len}, (x, i) => len - i);
+console.log(countdown);

--- a/test/mode_tests/javascript/advanced_test.js
+++ b/test/mode_tests/javascript/advanced_test.js
@@ -1,0 +1,66 @@
+/**
+ * @fileoverview Mode Javascript - Advanced
+ *
+ * @license Copyright 2018 The Coding with Chrome Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author mbordihn@google.com (Markus Bordihn)
+ */
+
+
+describe('[Mode Javascript - Advanced]', function() {
+  document.body.insertAdjacentHTML('afterbegin', '<div id="cwc-editor"></div>');
+  let builder = new cwc.ui.Builder();
+
+  describe('Prepare UI', function() {
+    it('export', function() {
+      expect(typeof builder).toEqual('object');
+      expect(typeof builder.decorate).toEqual('function');
+    });
+
+    it('decorate', function(done) {
+      builder.decorate(null, function() {
+        expect(builder.isPrepared()).toEqual(true);
+        expect(builder.isLoaded()).toEqual(true);
+        expect(builder.isReady()).toEqual(true);
+        done();
+      });
+    });
+  });
+
+  describe('Loading files', function() {
+    it('raw/blank.cwc', function(done) {
+      builder.loadFile(
+        'examples/../../resources/examples/javascript/raw/blank.js'
+      ).then(() => {
+        expect(true).toEqual(true);
+        done();
+      }, () => {
+        expect(false).toEqual(true);
+        done();
+      });
+    });
+    it('raw/Javascript-countdown.cwc', function(done) {
+      builder.loadFile(
+        'examples/../../resources/examples/javascript/raw/countdown.js'
+      ).then(() => {
+        expect(true).toEqual(true);
+        done();
+      }, () => {
+        expect(false).toEqual(true);
+        done();
+      });
+    });
+  });
+});


### PR DESCRIPTION
This change adds a Javascript mode and correctly handles .js
files.

Previously CWC included .js files as supported (i.e. they
showed up in the open file dialog when the user selected
"All Supported Files" as the file type), but opening .js
file resulted in no user-visible results and exception throw
in the console.

Note that there is a cwc.fileFormat.JavaScriptFile in src/file_format/file_format_type.js, but that code appears to be unused.