### PR TITLE
Add a field for addons to store data in .cwc files

### DIFF
--- a/src/addon/message/message.js
+++ b/src/addon/message/message.js
@@ -72,20 +72,27 @@ cwc.addon.Message.prototype.eventsModder = function(e) {
   let mode = e.data.mode;
   let fileName = e.data.file;
   this.log_.info('Change Mode', mode, 'for file', fileName);
-  let message = this.helper.getInstance('file').getFile().getAddon()['message'];
-  if (message) {
+  let content = this.helper.getInstance('file').getFile().getMetadata('content',
+    'message');
+  let help = this.helper.getInstance('file').getFile().getMetadata('help',
+    'message');
+  if (content || help) {
     this.log_.info('Adding message pane ...');
     let messageInstance = this.helper.getInstance('message');
     if (!messageInstance) return;
     messageInstance.show(true);
-    messageInstance.renderContent(cwc.soy.addon.Message.message, {
-      prefix: this.prefix,
-      message: message,
-    });
-    messageInstance.renderHelp(cwc.soy.addon.Message.help, {
-      prefix: this.prefix,
-      help: 'No help available',
-    });
+    if (content) {
+      messageInstance.renderContent(cwc.soy.addon.Message.message, {
+        prefix: this.prefix,
+        content: content,
+      });
+    }
+    if (help) {
+      messageInstance.renderHelp(cwc.soy.addon.Message.help, {
+        prefix: this.prefix,
+        help: help,
+      });
+    }
   }
 };
 

--- a/src/addon/message/message.js
+++ b/src/addon/message/message.js
@@ -1,0 +1,91 @@
+/**
+ * @fileoverview Message addon
+ *
+ * @license Copyright 2018 The Coding with Chrome Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author carheden@google.com (Adam Carheden)
+ */
+goog.provide('cwc.addon.Message');
+
+goog.require('cwc.mode.Modder.Events');
+goog.require('cwc.mode.Type');
+goog.require('cwc.soy.addon.Message');
+goog.require('cwc.ui.SelectScreen.Events');
+goog.require('cwc.utils.Logger');
+
+
+/**
+ * @param {!cwc.utils.Helper} helper
+ * @constructor
+ * @struct
+ * @final
+ */
+cwc.addon.Message = function(helper) {
+  /** @type {!string} */
+  this.name = 'Message';
+
+  /** @type {!cwc.utils.Helper} */
+  this.helper = helper;
+
+  /** @type {string} */
+  this.prefix = this.helper.getPrefix('addon-message');
+
+  /** @private {!boolean} */
+  this.chromeApp_ = this.helper.checkChromeFeature('app');
+
+  /** @private {!cwc.utils.Logger} */
+  this.log_ = new cwc.utils.Logger(this.name);
+};
+
+
+cwc.addon.Message.prototype.prepare = function() {
+  if (!this.helper.experimentalEnabled()) {
+    return;
+  }
+
+  this.log_.info('Preparing message addon ...');
+
+  let modeInstance = this.helper.getInstance('mode');
+  if (modeInstance) {
+    goog.events.listen(modeInstance.getEventHandler(),
+      cwc.mode.Modder.Events.Type.MODE_CHANGE,
+      this.eventsModder, false, this);
+  }
+};
+
+/**
+ * @param {Event} e
+ */
+cwc.addon.Message.prototype.eventsModder = function(e) {
+  let mode = e.data.mode;
+  let fileName = e.data.file;
+  this.log_.info('Change Mode', mode, 'for file', fileName);
+  let message = this.helper.getInstance('file').getFile().getAddon()['message'];
+  if (message) {
+    this.log_.info('Adding message pane ...');
+    let messageInstance = this.helper.getInstance('message');
+    if (!messageInstance) return;
+    messageInstance.show(true);
+    messageInstance.renderContent(cwc.soy.addon.Message.message, {
+      prefix: this.prefix,
+      message: message,
+    });
+    messageInstance.renderHelp(cwc.soy.addon.Message.help, {
+      prefix: this.prefix,
+      help: 'No help available',
+    });
+  }
+};
+

--- a/src/addon/message/message.soy
+++ b/src/addon/message/message.soy
@@ -24,10 +24,10 @@
  */
 {template .message}
   {@param prefix: string}
-  {@param message: string}
+  {@param content: string}
 
   <div id="{$prefix}main">
-		{$message}
+		{$content}
   </div>
 {/template}
 

--- a/src/addon/message/message.soy
+++ b/src/addon/message/message.soy
@@ -1,0 +1,44 @@
+/**
+ * @fileoverview Message pane template 
+ *
+ * @license Copyright 2018 The Coding with Chrome Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author carheden@google.com (Adam Carheden)
+ */
+{namespace cwc.soy.addon.Message autoescape="strict"}
+
+/**
+ * Message tab template.
+ */
+{template .message}
+  {@param prefix: string}
+  {@param message: string}
+
+  <div id="{$prefix}main">
+		{$message}
+  </div>
+{/template}
+
+/**
+ * Help tab template.
+ */
+{template .help}
+  {@param prefix: string}
+  {@param help: string}
+
+  <div id="{$prefix}help">
+		{$help}
+	</div>
+{/template}

--- a/src/addon/tutorial/tutorial.js
+++ b/src/addon/tutorial/tutorial.js
@@ -102,7 +102,7 @@ cwc.addon.Tutorial.prototype.eventsModder = function(e) {
     let messageInstance = this.helper.getInstance('message');
     if (messageInstance) {
       messageInstance.show(true);
-      messageInstance.renderContent(cwc.soy.addon.Tutorial.tutorial, {
+      messageInstance.renderMain(cwc.soy.addon.Tutorial.tutorial, {
         prefix: this.prefix,
       });
       let tour = new Shepherd.Tour({

--- a/src/addon/tutorial/tutorial.js
+++ b/src/addon/tutorial/tutorial.js
@@ -102,7 +102,7 @@ cwc.addon.Tutorial.prototype.eventsModder = function(e) {
     let messageInstance = this.helper.getInstance('message');
     if (messageInstance) {
       messageInstance.show(true);
-      messageInstance.renderMain(cwc.soy.addon.Tutorial.tutorial, {
+      messageInstance.renderContent(cwc.soy.addon.Tutorial.tutorial, {
         prefix: this.prefix,
       });
       let tour = new Shepherd.Tour({

--- a/src/addon/tutorial/tutorial.js
+++ b/src/addon/tutorial/tutorial.js
@@ -160,7 +160,7 @@ cwc.addon.Tutorial.prototype.loadFile_ = function(file_name) {
   if (loaderInstance) {
     loaderInstance.loadLocalFile(this.resourcesPath_ + file_name);
   }
-  let editorWindow = this.isChromeApp_ && chrome.app.window.get('editor');
+  let editorWindow = this.chromeApp_ && chrome.app.window.get('editor');
   if (editorWindow) {
     editorWindow['clearAttention']();
   }

--- a/src/file_format/file_format.js
+++ b/src/file_format/file_format.js
@@ -100,6 +100,9 @@ cwc.fileFormat.File = function(content = '') {
   /** @private {string} */
   this.version_ = '';
 
+  /** @private {object} */
+  this.addon_ = {};
+
   if (content) {
     this.loadJSON(content);
   } else {
@@ -131,6 +134,7 @@ cwc.fileFormat.File.prototype.init = function(silent = false) {
   this.type_ = cwc.file.Type.UNKNOWN;
   this.ui_ = 'default';
   this.version_ = '1.0';
+  this.addon_ = {};
 };
 
 
@@ -496,6 +500,21 @@ cwc.fileFormat.File.prototype.getHistory = function() {
   return this.history_;
 };
 
+/**
+ * @return {object}
+ */
+cwc.fileFormat.File.prototype.getAddon = function() {
+  return this.addon_;
+};
+
+/**
+ * @param {!object} addon
+ * @return {!cwc.fileFormat.File}
+ */
+cwc.fileFormat.File.prototype.setAddon = function(addon) {
+  this.addon_ = addon;
+  return this;
+};
 
 /**
  * Loads the defined JSON data and sets the supported options.
@@ -683,6 +702,10 @@ cwc.fileFormat.File.loadJSON = function(file, data) {
   if (jsonData['history']) {
     file.setHistory(jsonData['history']);
   }
+
+  if (jsonData['addon']) {
+    file.setAddon(jsonData['addon']);
+  }
 };
 
 
@@ -692,6 +715,7 @@ cwc.fileFormat.File.loadJSON = function(file, data) {
  */
 cwc.fileFormat.File.toJSON = function(file) {
   return {
+    'addon': file.addon_.toJSON(),
     'author': file.author_,
     'content': file.content_.toJSON(),
     'description': file.description_,

--- a/src/file_format/file_format.js
+++ b/src/file_format/file_format.js
@@ -100,7 +100,7 @@ cwc.fileFormat.File = function(content = '') {
   /** @private {string} */
   this.version_ = '';
 
-  /** @private {object} */
+  /** @private {!Object} */
   this.addon_ = {};
 
   if (content) {
@@ -501,14 +501,14 @@ cwc.fileFormat.File.prototype.getHistory = function() {
 };
 
 /**
- * @return {object}
+ * @return {!Object}
  */
 cwc.fileFormat.File.prototype.getAddon = function() {
   return this.addon_;
 };
 
 /**
- * @param {!object} addon
+ * @param {!Object} addon
  * @return {!cwc.fileFormat.File}
  */
 cwc.fileFormat.File.prototype.setAddon = function(addon) {

--- a/src/file_format/file_format.js
+++ b/src/file_format/file_format.js
@@ -101,7 +101,7 @@ cwc.fileFormat.File = function(content = '') {
   this.version_ = '';
 
   /** @private {!Object} */
-  this.addon_ = {};
+  this.metadata_ = {};
 
   if (content) {
     this.loadJSON(content);
@@ -134,7 +134,7 @@ cwc.fileFormat.File.prototype.init = function(silent = false) {
   this.type_ = cwc.file.Type.UNKNOWN;
   this.ui_ = 'default';
   this.version_ = '1.0';
-  this.addon_ = {};
+  this.metadata_ = {};
 };
 
 
@@ -501,19 +501,29 @@ cwc.fileFormat.File.prototype.getHistory = function() {
 };
 
 /**
- * @return {!Object}
+ * @param {!string} name
+ * @param {!string} namespace
+ * @return {*}
  */
-cwc.fileFormat.File.prototype.getAddon = function() {
-  return this.addon_;
+cwc.fileFormat.File.prototype.getMetadata = function(name,
+  namespace = 'default') {
+  if (!(namespace in this.metadata_) || !(name in this.metadata_[namespace])) {
+    return null;
+  }
+  return this.metadata_[namespace][name];
 };
 
 /**
- * @param {!Object} addon
- * @return {!cwc.fileFormat.File}
+ * @param {!string} name
+ * @param {*} value
+ * @param {!string} namespace
  */
-cwc.fileFormat.File.prototype.setAddon = function(addon) {
-  this.addon_ = addon;
-  return this;
+cwc.fileFormat.File.prototype.setMetadata = function(name, value,
+  namespace = 'default') {
+  if (!(namespace in this.metadata_)) {
+    this.metadata_[namespace] = {};
+  }
+  this.metadata_[namespace][name] = value;
 };
 
 /**
@@ -703,8 +713,8 @@ cwc.fileFormat.File.loadJSON = function(file, data) {
     file.setHistory(jsonData['history']);
   }
 
-  if (jsonData['addon']) {
-    file.setAddon(jsonData['addon']);
+  if (jsonData['metadata']) {
+    file.metadata_ = jsonData['metadata'];
   }
 };
 
@@ -715,7 +725,7 @@ cwc.fileFormat.File.loadJSON = function(file, data) {
  */
 cwc.fileFormat.File.toJSON = function(file) {
   return {
-    'addon': file.addon_.toJSON(),
+    'metadata': file.metadata_.toJSON(),
     'author': file.author_,
     'content': file.content_.toJSON(),
     'description': file.description_,

--- a/src/ui/builder.js
+++ b/src/ui/builder.js
@@ -24,6 +24,7 @@ goog.provide('cwc.ui.BuilderHelpers');
 
 goog.require('cwc.UserConfig');
 goog.require('cwc.addon.Tutorial');
+goog.require('cwc.addon.Message');
 goog.require('cwc.config');
 goog.require('cwc.fileHandler.File');
 goog.require('cwc.fileHandler.FileExporter');
@@ -77,6 +78,7 @@ goog.require('goog.dom');
  */
 cwc.ui.Addons = {
   'tutorial': cwc.addon.Tutorial,
+  'message': cwc.addon.Message,
 };
 
 

--- a/src/ui/message/message.js
+++ b/src/ui/message/message.js
@@ -44,7 +44,7 @@ cwc.ui.Message = function(helper) {
   this.node = null;
 
   /** @type {Element} */
-  this.nodeTutorial = null;
+  this.nodeMain = null;
 
   /** @type {Element} */
   this.nodeHelp = null;
@@ -90,4 +90,13 @@ cwc.ui.Message.prototype.show = function(visible) {
 cwc.ui.Message.prototype.renderContent = function(template, values) {
   goog.soy.renderElement(
     goog.dom.getElement(this.prefix + 'main'), template, values);
+};
+
+/**
+ * @param {!function (Object, null=, (Object<string,*>|null)=)} template
+ * @param {!Object} values
+ */
+cwc.ui.Message.prototype.renderHelp = function(template, values) {
+  goog.soy.renderElement(
+    goog.dom.getElement(this.prefix + 'help'), template, values);
 };

--- a/static_files/resources/examples/simple/message/message.cwc
+++ b/static_files/resources/examples/simple/message/message.cwc
@@ -1,0 +1,28 @@
+{
+   "addon" : {
+      "message" : "This is an example of 'Hello, World' written in JavaScript. 'Hello, World' is typically the first code a programmer writes when learning a new programming language. It's simple but demonstrates how to send a message to the user."
+   },
+   "history" : "",
+   "flags" : {},
+   "version" : "1.0",
+   "ui" : "default",
+   "format" : "Coding with Chrome File Format 2",
+   "title" : "Tutorial Example",
+   "mode" : "basic",
+   "files" : {},
+   "description" : "",
+   "frameworks" : {},
+   "author" : "Unknown",
+   "type" : "basic",
+   "content" : {
+      "__javascript__" : {
+         "group" : "",
+         "filename" : "message.js",
+         "version" : 1,
+         "name" : "__javascript__",
+         "content" : "console.log('Hello, world')",
+         "type" : "application/javascript",
+         "size" : 0
+      }
+   }
+}

--- a/static_files/resources/examples/simple/message/message.cwc
+++ b/static_files/resources/examples/simple/message/message.cwc
@@ -1,6 +1,9 @@
 {
-   "addon" : {
-      "message" : "This is an example of 'Hello, World' written in JavaScript. 'Hello, World' is typically the first code a programmer writes when learning a new programming language. It's simple but demonstrates how to send a message to the user."
+   "metadata" : {
+      "message" : {
+        "content": "This is an example of 'Hello, World' written in JavaScript. 'Hello, World' is typically the first code a programmer writes when learning a new programming language. It's simple but demonstrates how to send a message to the user.",
+        "help": "No help available"
+			}
    },
    "history" : "",
    "flags" : {},

--- a/test/unit_tests/file_format/file_format_test.js
+++ b/test/unit_tests/file_format/file_format_test.js
@@ -65,6 +65,10 @@ describe('File format', function() {
     'ui': 'default',
     'version': '1.0',
   };
+  let addonContent = {};
+  let addonKey = Math.random().toString(36).replace();
+  let addonValue = Math.random().toString(36).replace();
+  addonContent[addonKey] = addonValue;
 
   it('constructor', function() {
     expect(typeof fileFormat).toEqual('object');
@@ -135,6 +139,18 @@ describe('File format', function() {
 
   it('hasFiles', function() {
     expect(fileFormat.hasFiles()).toEqual(false);
+  });
+
+  it('getAddon (empty)', function() {
+    expect(fileFormat.getAddon()).toEqual({});
+  });
+
+  it('setAddon', function() {
+    fileFormat.setAddon(addonContent);
+  });
+
+  it('getAddon', function() {
+    expect(fileFormat.getAddon()).toEqual(addonContent);
   });
 
   describe('Legacy format', function() {

--- a/test/unit_tests/file_format/file_format_test.js
+++ b/test/unit_tests/file_format/file_format_test.js
@@ -65,10 +65,13 @@ describe('File format', function() {
     'ui': 'default',
     'version': '1.0',
   };
-  let addonContent = {};
-  let addonKey = Math.random().toString(36).replace();
-  let addonValue = Math.random().toString(36).replace();
-  addonContent[addonKey] = addonValue;
+  let metadataKey1 = Math.random().toString(36).replace();
+  let metadataValue1 = Math.random().toString(36).replace();
+  let metadataNamespace = Math.random().toString(36).replace();
+  let metadataKey2 = Math.random().toString(36).replace();
+  let metadataInnerKey = Math.random().toString(36).replace();
+  let metadataValue2 = {};
+  metadataValue2[metadataInnerKey] = Math.random().toString(36).replace();
 
   it('constructor', function() {
     expect(typeof fileFormat).toEqual('object');
@@ -141,16 +144,43 @@ describe('File format', function() {
     expect(fileFormat.hasFiles()).toEqual(false);
   });
 
-  it('getAddon (empty)', function() {
-    expect(fileFormat.getAddon()).toEqual({});
+  it('getMetadata (unset, default namespace)', function() {
+    expect(fileFormat.getMetadata(metadataKey1)).toEqual(null);
   });
 
-  it('setAddon', function() {
-    fileFormat.setAddon(addonContent);
+  it('getMetadata (unset, non-default namespace)', function() {
+    expect(fileFormat.getMetadata(metadataKey1,
+      metadataNamespace)).toEqual(null);
   });
 
-  it('getAddon', function() {
-    expect(fileFormat.getAddon()).toEqual(addonContent);
+  it('setMetadata (default namespace)', function() {
+    expect(() => {
+      fileFormat.setMetadata(metadataKey1, metadataValue1);
+    }).not.toThrow();
+  });
+
+  it('getMetadata (default namespace, set)', function() {
+    expect(fileFormat.getMetadata(metadataKey1)).toEqual(metadataValue1);
+  });
+
+  it('setMetadata (non-default namespace)', function() {
+    expect(() => {
+      fileFormat.setMetadata(metadataKey2, metadataValue2, metadataNamespace);
+    }).not.toThrow();
+  });
+
+  it('getMetadata (non-default namespace, wrong key)', function() {
+    expect(fileFormat.getMetadata(metadataKey1,
+      metadataNamespace)).toEqual(null);
+  });
+
+  it('getMetadata (non-default namespace, correct key)', function() {
+    expect(fileFormat.getMetadata(metadataKey2,
+      metadataNamespace)).toEqual(metadataValue2);
+  });
+
+  it('getMetadata (default namespace, wrong key)', function() {
+    expect(fileFormat.getMetadata(metadataKey2)).toEqual(null);
   });
 
   describe('Legacy format', function() {


### PR DESCRIPTION
How about this as a way to addons to store data in cwc files? It just adds a field to file_format. It includes unit tests and an example add-on that displays a message in the message pane.

You can try out an example file at static_files/resources/examples/simple/message/message.cwc. You'll need to use the file open dialog, as there's nothing in the select screens that point to that file.

Note that my plan to add a tutorial feature needs some place to store it's data, so this seemed like a minimally intrusive way to modify the .cwc file format both for that purpose and future features that can be implemented as add-ons.