### PR TITLE
Fixed window failing to close on Linux

### DIFF
--- a/src/ui/menubar/menubar.js
+++ b/src/ui/menubar/menubar.js
@@ -326,7 +326,8 @@ cwc.ui.Menubar.prototype.closeWindow = function() {
         bluetoothInstance.closeSockets();
       }
     } else {
-      this.log_.warn('Failed to get Features helper. Can\'t check if bluetoothSocket is suppoeted');
+      this.log_.warn('Failed to get Features helper.'+
+        'Can\'t check if bluetoothSocket is supported');
     }
   }
   this.currentWindow['close']();

--- a/src/ui/menubar/menubar.js
+++ b/src/ui/menubar/menubar.js
@@ -320,7 +320,14 @@ cwc.ui.Menubar.prototype.closeWindow = function() {
   this.log_.info('Close Coding with Chrome editor ...');
   let bluetoothInstance = this.helper.getInstance('bluetooth');
   if (bluetoothInstance) {
-    bluetoothInstance.closeSockets();
+    let featuresInstance = this.helper.getInstance('features');
+    if (featuresInstance) {
+      if (featuresInstance.getChromeFeature('bluetoothSocket')) {
+        bluetoothInstance.closeSockets();
+      }
+    } else {
+      this.log_.warn('Failed to get Features helper. Can\'t check if bluetoothSocket is suppoeted');
+    }
   }
   this.currentWindow['close']();
 };


### PR DESCRIPTION
CwC wouldn't close for me on Linux recently. It threw an exception on line 113 of src/protocol/low-level/bluetooth/classic/devices.js about getSockets() not being a method of 'undefined'. I think the root cause is that bluetoothSocket isn't supported on Windows (see https://developer.chrome.com/apps/bluetoothSocket). This should fix the issue by only attempting to make that call if the bluetoothSockets API is defined.

