### PR TITLE
Fixed hidden toolbars @ width < 1024px

### DIFF
--- a/src/ui/blockly/toolbar/blockly_toolbar.gss
+++ b/src/ui/blockly/toolbar/blockly_toolbar.gss
@@ -16,6 +16,7 @@
 
 #{$prefix}blockly-toolbar {
   min-height: 34px;
+  display: flex !important;
 }
 
 #{$prefix}blockly-toolbar > .mdl-layout__header-row {

--- a/src/ui/editor/infobar/editor_infobar.gss
+++ b/src/ui/editor/infobar/editor_infobar.gss
@@ -20,6 +20,7 @@
   background: #f5f5f5;
   border-top: 1px solid #e5e5e5;
   border-bottom: 1px solid #ebebeb;
+  display: flex !important;
 }
 
 #{$prefix}editor-infobar .goog-menu-button {

--- a/src/ui/editor/toolbar/editor_toolbar.gss
+++ b/src/ui/editor/toolbar/editor_toolbar.gss
@@ -15,6 +15,9 @@
  */
 
 
+#{$prefix}editor-toolbar {
+  display: flex !important;
+}
 #{$prefix}editor-toolbar > .mdl-layout__header-row {
   height: 34px;
 }

--- a/src/ui/preview/infobar/preview_infobar.gss
+++ b/src/ui/preview/infobar/preview_infobar.gss
@@ -15,6 +15,9 @@
  */
 
 
+#{$prefix}preview-infobar {
+  display: flex !important;
+}
 .{$prefix}preview-infobar-num {
   position: absolute;
   right: 0;

--- a/src/ui/preview/toolbar/preview_toolbar.gss
+++ b/src/ui/preview/toolbar/preview_toolbar.gss
@@ -18,6 +18,7 @@
 #{$prefix}preview-toolbar {
   flex: 0 1 auto;
   min-height: 34px;
+  display: flex !important;
 }
 
 #{$prefix}preview-toolbar > .mdl-layout__header-row {


### PR DESCRIPTION
MDL hides headers and footers (which we use for the toolbars and
infobars) at screen widths < 1024. But this simply leaves unused
whitespace at the bottom of the screen in CwC. These CSS changes
override that MLD behavior.