### PR TITLE
Added tabbed third pane

### DIFF
--- a/build/external/extra_files.js
+++ b/build/external/extra_files.js
@@ -184,3 +184,15 @@ closureBuilder.build({
   ],
   out: 'genfiles/third_party/external/shepherd',
 });
+
+/**
+ * Closure
+ */
+closureBuilder.build({
+  name: 'Closure css',
+  resources: [
+    'third_party/closure-library/closure/goog/css/roundedtab.css',
+    'third_party/closure-library/closure/goog/css/tabbar.css',
+  ],
+  out: 'genfiles/third_party/external/closure-library/closure/goog/css',
+});

--- a/src/addon/tabbed_pane/tabbed_pane.js
+++ b/src/addon/tabbed_pane/tabbed_pane.js
@@ -1,0 +1,312 @@
+/**
+ * @fileoverview Tabbed Pane Addon
+ *
+ * @license Copyright 2018 The Coding with Chrome Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author carheden@google.com (Adam Carheden)
+ */
+goog.provide('cwc.addon.TabbedPane');
+goog.require('cwc.utils.Logger');
+goog.require('goog.dom');
+goog.require('goog.dom.classes');
+goog.require('goog.events.EventTarget');
+goog.require('goog.events.EventType');
+goog.require('goog.math.Size');
+goog.require('goog.soy');
+goog.require('goog.style');
+goog.require('goog.ui.Component');
+goog.require('goog.ui.RoundedTabRenderer');
+goog.require('goog.ui.SplitPane');
+goog.require('goog.ui.SplitPane.Orientation');
+goog.require('goog.ui.Tab');
+goog.require('goog.ui.TabBar');
+
+/**
+ * @param {!cwc.utils.Helper} helper
+ * @constructor
+ * @struct
+ * @final
+ */
+cwc.addon.TabbedPane = function(helper) {
+  /** @type {!string} */
+  this.name = 'Tabbed Pane Addon';
+
+  /** @type {!cwc.utils.Helper} */
+  this.helper = helper;
+
+  /** @type {string} */
+  this.prefix = this.helper.getPrefix('addon-tabbed_pane');
+
+  /** @private {!cwc.utils.Logger} */
+  this.log_ = new cwc.utils.Logger(this.name);
+
+  /** @private {Element} */
+  this.container = null;
+
+  /** @private {Element} */
+  this.content = null;
+
+  /** @private {goog.ui.SplitPane} */
+  this.splitPane = null;
+
+  /** @private {goog.ui.TabBar} */
+  this.tabBar = null;
+
+  /** @private {goog.ui.Tab} */
+  this.centerTab = null;
+
+  /** @private {goog.ui.Tab} */
+  this.contentTab = null;
+
+  /** @private {!number} */
+  this.minContentWidth = 1024 / 2;
+};
+
+cwc.addon.TabbedPane.prototype.prepare = function() {
+  if (!this.helper.experimentalEnabled()) {
+    this.log_.info('not in experimental mode, disabling');
+    return;
+  }
+  this.log_.info('tabbed pane available');
+};
+
+/**
+ * @param {!function ({prefix: string}, null=): soydata.SanitizedHtml} template
+ * @param {Object} templateData
+ * @param {string} contentTabName
+ * @param {string} centerTabName
+ * @param {number} initial_width
+ */
+cwc.addon.TabbedPane.prototype.renderContent = function(template, templateData,
+  contentTabName = 'Instructions', centerTabName = 'Preview',
+  initial_width = null) {
+  // Get dependent objects
+  let layoutInstance = this.helper.getInstance('layout');
+  if (!layoutInstance) {
+    this.log_.info('No layout, quitting...');
+    return;
+  }
+  let contentMiddle = layoutInstance.getNode('content-middle');
+  if (!contentMiddle) {
+    this.log_.info('No content-middle, quitting...');
+    return;
+  }
+  let contentRight = layoutInstance.getNode('content-right');
+  if (!contentRight) {
+    this.log_.info('No content-right, quitting...');
+    return;
+  }
+  let chromeMain = layoutInstance.getNode_('chrome-main');
+  if (!chromeMain) {
+    this.log_.info('No chrome-main, quitting...');
+    return;
+  }
+
+  // Disable the layout's events
+  if (!goog.events.unlisten(layoutInstance.viewport_monitor,
+    goog.events.EventType.RESIZE, layoutInstance.adjustSize, false,
+    layoutInstance)) {
+    this.log_.warn('Failed to unlisten to window resize');
+  }
+  if (!goog.events.listen(layoutInstance.firstSplitpane,
+    goog.ui.SplitPane.EventType.HANDLE_DRAG,
+    layoutInstance.adjustSize, false, layoutInstance)) {
+    this.log_.warn('Failed to unlisten to handle drag');
+  }
+  if (!goog.events.listen(layoutInstance.firstSplitpane,
+    goog.ui.SplitPane.EventType.HANDLE_SNAP,
+    layoutInstance.adjustSize, false, layoutInstance)) {
+    this.log_.warn('Failed to unlisten to handle snap');
+  }
+
+  // Destroy the layout's splitpane
+  let first_splitpane_size =
+    layoutInstance.firstSplitpane.getFirstComponentSize();
+  layoutInstance.firstSplitpane.dispose();
+
+  // Add the require <div>s to the DOM
+  goog.dom.classes.remove(contentRight, 'goog-splitpane-second-container');
+  let outerRight = goog.dom.createDom('div',
+    {'class': 'goog-splitpane-second-container'});
+  goog.dom.insertSiblingAfter(outerRight, contentMiddle);
+  this.container = goog.dom.createDom('div', {'id': this.prefix+'container',
+    'class': 'goog-splitpane'});
+  goog.dom.appendChild(outerRight, this.container);
+  goog.dom.appendChild(this.container, contentRight);
+  goog.dom.classes.add(contentRight, 'goog-splitpane-first-container');
+  this.content = goog.dom.createDom('div',
+    {'id': this.prefix+'content', 'class': 'goog-splitpane-second-container'},
+    '');
+  goog.dom.appendChild(this.container, this.content);
+  goog.dom.appendChild(this.container, goog.dom.createDom('div',
+    {'id': this.prefix+'handle', 'class': 'goog-splitpane-handle'}));
+
+  // Create the tab bar
+  let tabbar = goog.dom.createDom('div',
+    {'id': this.prefix+'tab_bar', 'class': 'goog-tab-bar-bottom'});
+  goog.dom.appendChild(tabbar, goog.dom.createDom('div',
+    {'id': this.prefix+'tab_center',
+    'class': 'goog-rounded-tab goog-rounded-tab-selected'}, centerTabName));
+  goog.dom.appendChild(tabbar, goog.dom.createDom('div',
+    {'id': this.prefix+'tab_right', 'class': 'goog-rounded-tab'},
+     contentTabName));
+  goog.dom.appendChild(outerRight, goog.dom.createDom('div',
+    {'class': 'goog-tab-bar-clear'}));
+  goog.dom.appendChild(outerRight, tabbar);
+  this.tabBar = new goog.ui.TabBar();
+  this.tabBar.decorate(tabbar);
+  goog.events.listen(this.tabBar, goog.ui.Component.EventType.SELECT, (e) => {
+    switch (e.target.getId()) {
+      case this.prefix+'tab_center':
+        break;
+      case this.prefix+'tab_right':
+        break;
+      default:
+        this.log_.error('Unknown tab: "'+e.target.getId()+'"');
+    }
+    this.adjustSize();
+  });
+
+  // Re-create the layout's splitpane
+  layoutInstance.firstSplitpane = new goog.ui.SplitPane(new goog.ui.Component(),
+    new goog.ui.Component(), goog.ui.SplitPane.Orientation.HORIZONTAL);
+  layoutInstance.firstSplitpane.setInitialSize(first_splitpane_size);
+  layoutInstance.firstSplitpane.setHandleSize(layoutInstance.handleSize);
+  layoutInstance.firstSplitpane.decorate(chromeMain);
+  layoutInstance.firstSplitpane.setFirstComponentSize(first_splitpane_size);
+
+  // Create out splitpane
+  let maxWidth = layoutInstance.chromeSize.width - first_splitpane_size;
+  let second_splitpane_size = initial_width ?
+    Math.max(0, maxWidth - initial_width) :
+    maxWidth / 2;
+  this.splitPane = new goog.ui.SplitPane(new goog.ui.Component(),
+    new goog.ui.Component(), goog.ui.SplitPane.Orientation.HORIZONTAL);
+  this.splitPane.setInitialSize(second_splitpane_size);
+  this.splitPane.setHandleSize(layoutInstance.handleSize);
+  this.splitPane.decorate(this.container);
+
+  // Set up all events
+  goog.events.listen(layoutInstance.viewport_monitor,
+    goog.events.EventType.RESIZE, this.adjustSize, false, this);
+  goog.events.listen(layoutInstance.firstSplitpane,
+      goog.ui.SplitPane.EventType.HANDLE_DRAG,
+    this.adjustSize, false, this);
+  goog.events.listen(layoutInstance.firstSplitpane,
+    goog.ui.SplitPane.EventType.HANDLE_SNAP,
+    this.adjustSize, false, this);
+  goog.events.listen(this.splitPane, goog.ui.SplitPane.EventType.HANDLE_DRAG,
+    this.adjustSize, false, this);
+  goog.events.listen(this.splitPane, goog.ui.SplitPane.EventType.HANDLE_SNAP,
+    this.adjustSize, false, this);
+
+  // Size the layout
+  this.adjustSize();
+
+  // Render the user's content
+  goog.soy.renderElement(this.content, template, templateData);
+};
+
+cwc.addon.TabbedPane.prototype.contentActive = function() {
+  if (!this.tabBar) return false;
+  let selected = this.tabBar.getSelectedTab();
+  if (!selected) return false;
+  return selected.getId() == this.prefix+'tab_right';
+};
+
+cwc.addon.TabbedPane.prototype.adjustSize = function() {
+  let layoutInstance = this.helper.getInstance('layout');
+  if (!layoutInstance) {
+    this.log_.info('No layout, quitting...');
+    return;
+  }
+
+  let firstSplitpaneComponentWidth = null;
+  layoutInstance.updateSizeInformation();
+  layoutInstance.adjustLayoutChrome();
+
+  switch (layoutInstance.layout) {
+    case cwc.ui.LayoutType.BLANK: {
+      goog.style.setSize(layoutInstance.nodes['content'],
+        layoutInstance.chromeSize);
+      break;
+    }
+    case cwc.ui.LayoutType.DEFAULT: {
+      if (!layoutInstance.fullscreen) {
+        if (layoutInstance.fixRightComponentSize) {
+          firstSplitpaneComponentWidth = layoutInstance.chromeSize.width -
+           layoutInstance.handleSize - layoutInstance.fixRightComponentSize;
+        }
+      }
+      layoutInstance.firstSplitpane.setSize(layoutInstance.chromeSize,
+        firstSplitpaneComponentWidth);
+      let secondSplitpaneWidth = layoutInstance.chromeSize.width -
+        layoutInstance.firstSplitpane.getFirstComponentSize();
+      const tabBarHeight = 30;
+      let handleWidth = 10;
+      let secondSplitpaneHeight = layoutInstance.chromeSize.height;
+      let tabBar = goog.dom.getElement(this.prefix+'tab_bar');
+      let rightPane = goog.dom.getElement(this.prefix+'content');
+      let centerWidth;
+      let rightWidth;
+      let secondSplitpaneComponentWidth;
+      if (secondSplitpaneWidth < this.minContentWidth) {
+        goog.style.setElementShown(tabBar, true);
+        secondSplitpaneHeight = Math.max(0, secondSplitpaneHeight -
+          tabBarHeight);
+        let width = Math.max(0, Math.floor(secondSplitpaneWidth - handleWidth));
+        if (this.contentActive()) {
+          centerWidth = 0;
+          rightWidth = width;
+          secondSplitpaneComponentWidth = -handleWidth * 2;
+        } else {
+          centerWidth = width;
+          rightWidth = 0;
+          secondSplitpaneComponentWidth = secondSplitpaneWidth;
+        }
+      } else {
+        goog.style.setElementShown(tabBar, false);
+        centerWidth = this.splitPane.getFirstComponentSize();
+        rightWidth = Math.max(0, Math.floor(secondSplitpaneWidth -
+          this.splitPane.getFirstComponentSize() - handleWidth * 2));
+        if (this.splitPane.getFirstComponentSize() <= 0) {
+          secondSplitpaneComponentWidth = Math.max(0, secondSplitpaneWidth / 2);
+        }
+      }
+      let secondSplitpaneSize = new goog.math.Size(secondSplitpaneWidth,
+        secondSplitpaneHeight);
+      this.splitPane.setSize(secondSplitpaneSize,
+        secondSplitpaneComponentWidth);
+
+      let paneCenterSize = new goog.math.Size(centerWidth,
+        secondSplitpaneHeight);
+      goog.style.setSize(layoutInstance.getNode('content-right'),
+        paneCenterSize);
+      let paneRightSize = new goog.math.Size(rightWidth, secondSplitpaneHeight);
+      goog.style.setSize(rightPane, paneRightSize);
+
+      break;
+    }
+    case cwc.ui.LayoutType.NONE: {
+      break;
+    }
+    default: {
+      console.error('Unknown layout:', layoutInstance.layout);
+      break;
+    }
+  }
+  layoutInstance.handleResizeEvent();
+};
+

--- a/src/addon/tutorial/tutorial.js
+++ b/src/addon/tutorial/tutorial.js
@@ -114,48 +114,47 @@ cwc.addon.Tutorial.prototype.eventsModder = function(e) {
   let mode = e.data.mode;
   let file = e.data.file;
   this.log_.info('Change Mode', mode, 'for file', file);
-  if (mode == cwc.mode.Type.BASIC_BLOCKLY && file == 'tutorial-1.cwc') {
-    this.log_.info('Adding message pane ...');
-    let messageInstance = this.helper.getInstance('message');
-    if (messageInstance) {
-      messageInstance.show(true);
-      messageInstance.renderContent(cwc.soy.addon.Tutorial.tutorial, {
-        prefix: this.prefix,
-      });
-      let tour = new Shepherd.Tour({
-        'defaults': {
-          'classes': 'shepherd-theme-arrows',
-          'showCancelLink': true,
-        },
-      });
-      tour.addStep('workspace', {
-        'title': i18t('Tutorial'),
-        'text': i18t('This is the workspace area to drop blocks.'),
-        'attachTo': '#cwc-blockly-chrome center',
-        'buttons': [{
-          'text': i18t('Exit'),
-          'action': tour.cancel,
-          'classes': 'shepherd-button-secondary',
-        }, {
-          'text': i18t('Next'),
-          'action': tour.next,
-          'classes': 'shepherd-button-example-primary',
-        }],
-      });
-      tour.addStep('blocks', {
-        'text': i18t('Drag and drop blocks from here to the workspace area.'),
-        'attachTo': '.blocklyToolboxDiv left',
-        'buttons': [{
-          'text': i18t('Exit'),
-          'action': tour.cancel,
-          'classes': 'shepherd-button-example-primary',
-        }],
-      });
-      tour.start();
-    }
-  }
-};
+  if (mode != cwc.mode.Type.BASIC_BLOCKLY || file != 'tutorial-1.cwc') return;
 
+  let tabbedPaneInstance = this.helper.getAddon('tabbedPane');
+  if (!tabbedPaneInstance) {
+    this.log_.error('Tabbed pane Add-on missing');
+    return;
+  }
+  this.log_.info('Adding tabbed pane ...');
+  tabbedPaneInstance.renderContent(cwc.soy.addon.Tutorial.tutorial,
+    {prefix: this.prefix}, 'Tutorial', 'Blockly');
+  let tour = new Shepherd.Tour({
+    'defaults': {
+      'classes': 'shepherd-theme-arrows',
+      'showCancelLink': true,
+    },
+  });
+  tour.addStep('workspace', {
+    'title': i18t('Tutorial'),
+    'text': i18t('This is the workspace area to drop blocks.'),
+    'attachTo': '#cwc-blockly-chrome center',
+    'buttons': [{
+      'text': i18t('Exit'),
+      'action': tour.cancel,
+      'classes': 'shepherd-button-secondary',
+    }, {
+      'text': i18t('Next'),
+      'action': tour.next,
+      'classes': 'shepherd-button-example-primary',
+    }],
+  });
+  tour.addStep('blocks', {
+    'text': i18t('Drag and drop blocks from here to the workspace area.'),
+    'attachTo': '.blocklyToolboxDiv left',
+    'buttons': [{
+      'text': i18t('Exit'),
+      'action': tour.cancel,
+      'classes': 'shepherd-button-example-primary',
+    }],
+  });
+  tour.start();
+};
 
 /**
  * Loads file into editor.

--- a/src/ui/builder.js
+++ b/src/ui/builder.js
@@ -25,6 +25,7 @@ goog.provide('cwc.ui.BuilderHelpers');
 goog.require('cwc.Cache');
 goog.require('cwc.UserConfig');
 goog.require('cwc.addon.Message');
+goog.require('cwc.addon.TabbedPane');
 goog.require('cwc.addon.Tutorial');
 goog.require('cwc.config');
 goog.require('cwc.fileHandler.File');
@@ -78,6 +79,7 @@ goog.require('goog.dom');
  */
 cwc.ui.Addons = {
   'message': cwc.addon.Message,
+  'tabbedPane': cwc.addon.TabbedPane,
   'tutorial': cwc.addon.Tutorial,
 };
 

--- a/static_files/css/closure/closure.css
+++ b/static_files/css/closure/closure.css
@@ -26,8 +26,8 @@
 @import 'menuitem.css';
 @import 'splitpane.css';
 
-@import '../../external/closure/roundedtab.css';
-@import '../../external/closure/tabbar.css';
+@import '../../external/closure-library/closure/goog/css/roundedtab.css';
+@import '../../external/closure-library/closure/goog/css/tabbar.css';
 
 .modal-dialog, .modal-dialog-bg, .goog-menu {
   z-index: 100;

--- a/static_files/css/closure/closure.css
+++ b/static_files/css/closure/closure.css
@@ -26,6 +26,9 @@
 @import 'menuitem.css';
 @import 'splitpane.css';
 
+@import '../../external/closure/roundedtab.css';
+@import '../../external/closure/tabbar.css';
+
 .modal-dialog, .modal-dialog-bg, .goog-menu {
   z-index: 100;
 }

--- a/static_files/resources/tutorial/simple/blocks/tutorial-1.cwc
+++ b/static_files/resources/tutorial/simple/blocks/tutorial-1.cwc
@@ -6,14 +6,14 @@
       "type": "application/blockly+xml",
       "size": 48,
       "content": "<xml xmlns=\"http://www.w3.org/1999/xhtml\"></xml>",
-      "version": 1,
+      "version": 1
     },
     "__javascript__": {
       "name": "__javascript__",
       "type": "application/javascript",
       "size": 0,
       "content": "",
-      "version": 1,
+      "version": 1
     }
   },
   "description": "",


### PR DESCRIPTION
How about this for the tabbed third pane?

* Hidden behind experimental flag
* Reusable by other addons

Known limitations:
* The rightmost pane of cwc core always becomes the 'shared' pane.

We probably usually want to share the preview pane rather than the editor pane. The editor pane is on the left for most modes but on the right for blockly. It should be possible to make which pane is shared configurable, but it's somewhat more complicated. I figured its best to get this version submitted so we can start code review, unblock Workbench, find bugs and have the team opine on the shared tabbed pane paradigm.

