### PR TITLE
Other projects use the notation GitHub, but this project was fixed as Github.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,7 +46,7 @@ into the master branch and part of the bundled application.
 
 ### Code reviews
 All submissions, including submissions by project members, require review. We
-use Github pull requests for this purpose.
+use GitHub pull requests for this purpose.
 
 
 ### The small print


### PR DESCRIPTION
Hi. I use Google services frequently.

I'm a favorite company and I hope to contribute to Google. This time, I will send you PR because I found a point that I can correct about the notation of `Github`.

Other projects use the notation `GitHub`, but this project was fixed as `Github`.

thank you.