### PR TITLE
Reimplement Workbench integration as addon

### DIFF
--- a/src/addon/workbench/workbench.js
+++ b/src/addon/workbench/workbench.js
@@ -1,0 +1,238 @@
+/**
+ * @fileoverview Workbench addon
+ *
+ * @license Copyright 2018 The Coding with Chrome Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author mdiehl@workbenchplatform.com (Matt Diehl)
+ */
+goog.provide('cwc.addon.Workbench');
+
+goog.require('cwc.addon.WorkbenchLoader');
+goog.require('cwc.addon.WorkbenchProject');
+goog.require('cwc.mode.Type');
+goog.require('cwc.soy.SelectScreenTemplate');
+goog.require('cwc.ui.SelectScreen.Events');
+goog.require('cwc.utils.Logger');
+
+// tagMap keys are tags on Workbench
+const tagMap = {
+  'CWC Advanced - 3D': {
+    appendNode: '#select-screen-tab-graphic .cwc-tutorial-list',
+    mode: cwc.mode.Type.BASIC,
+  },
+  'CWC Advanced - CoffeeScript': {
+    appendNode: '#select-screen-tab-coffeescript .cwc-tutorial-list',
+    mode: cwc.mode.Type.COFFEESCRIPT,
+  },
+  'CWC Advanced - EV3': {
+    appendNode: '#select-screen-tab-lego_ev3 .cwc-tutorial-list',
+    mode: cwc.mode.Type.EV3,
+  },
+  'CWC Advanced - Games': {
+    appendNode: '#select-screen-tab-games .cwc-tutorial-list',
+    mode: cwc.mode.Type.PHASER,
+  },
+  'CWC Advanced - HTML5': {
+    appendNode: '#select-screen-tab-html5 .cwc-tutorial-list',
+    mode: cwc.mode.Type.HTML5,
+  },
+  'CWC Advanced - JavaScript': {
+    appendNode: '#select-screen-tab-javascript .cwc-tutorial-list',
+    mode: cwc.mode.Type.JAVASCRIPT,
+  },
+  'CWC Advanced - Pencil Code': {
+    appendNode: '#select-screen-tab-pencil_code .cwc-tutorial-list',
+    mode: cwc.mode.Type.PENCIL_CODE,
+  },
+  'CWC Advanced - Python 2.7': {
+    appendNode: '#select-screen-tab-python27 .cwc-tutorial-list',
+    mode: cwc.mode.Type.PYTHON27,
+  },
+  'CWC Advanced - Python 3.x': {
+    appendNode: '#select-screen-tab-python .cwc-tutorial-list',
+    mode: cwc.mode.Type.PYTHON,
+  },
+  'CWC Advanced - Simple': {
+    appendNode: '#select-screen-tab-basic .cwc-tutorial-list',
+    mode: cwc.mode.Type.BASIC,
+  },
+  'CWC Advanced - Sphero 2.0': {
+    appendNode: '#select-screen-tab-sphero_classic .cwc-tutorial-list',
+    mode: cwc.mode.Type.SPHERO,
+  },
+  'CWC Advanced - Sphero BB-8': {
+    appendNode: '#select-screen-tab-sphero_bb8 .cwc-tutorial-list',
+    mode: 'sphero_bb8', // TODO: this is missing
+  },
+  'CWC Advanced - Sphero SPRK+': {
+    appendNode: '#select-screen-tab-sphero_sprk_plus .cwc-tutorial-list',
+    mode: cwc.mode.Type.SPHERO_SPRK_PLUS,
+  },
+  'CWC Beginner - Blocks': {
+    appendNode: '#select-screen-tab-blocks .cwc-tutorial-list',
+    mode: cwc.mode.Type.BASIC_BLOCKLY,
+  },
+  'CWC Beginner - EV3': {
+    appendNode: '#select-screen-tab-lego_ev3 .cwc-tutorial-list',
+    mode: cwc.mode.Type.EV3_BLOCKLY,
+  },
+  'CWC Beginner - Games': {
+    appendNode: '#select-screen-tab-games .cwc-tutorial-list',
+    mode: cwc.mode.Type.PHASER_BLOCKLY,
+  },
+  'CWC Beginner - Sphero 2.0': {
+    appendNode: '#select-screen-tab-sphero_classic .cwc-tutorial-list',
+    mode: cwc.mode.Type.SPHERO_BLOCKLY,
+  },
+  'CWC Beginner - Sphero BB-8': {
+    appendNode: '#select-screen-tab-sphero_bb8 .cwc-tutorial-list',
+    mode: cwc.mode.Type.SPHERO_BB8_BLOCKLY,
+  },
+  'CWC Beginner - Sphero SPRK+': {
+    appendNode: '#select-screen-tab-sphero_sprk_plus .cwc-tutorial-list',
+    mode: cwc.mode.Type.SPHERO_SPRK_PLUS_BLOCKLY,
+  },
+  'CWC Beginner - mBot Blue': {
+    appendNode: '#select-screen-tab-makeblock_mbot .cwc-tutorial-list',
+    mode: cwc.mode.Type.MBOT_BLOCKLY,
+  },
+  'CWC Beginner - mBot Ranger': {
+    appendNode: '#select-screen-tab-makeblock_mbot_ranger .cwc-tutorial-list',
+    mode: cwc.mode.Type.MBOT_RANGER_BLOCKLY,
+  },
+};
+
+
+/**
+ * @param {!cwc.utils.Helper} helper
+ * @constructor
+ * @struct
+ * @final
+ */
+cwc.addon.Workbench = function(helper) {
+  /** @type {!string} */
+  this.name = 'Workbench';
+
+  /** @type {!cwc.utils.Helper} */
+  this.helper = helper;
+
+  /** @private {!cwc.utils.Database} */
+  this.projectsDb_ = new cwc.utils.Database('Workbench Projects')
+    .setObjectStoreName('__workbench_projects__');
+
+  /** @private {!cwc.utils.Database} */
+  this.imagesDb_ = new cwc.utils.Database('Workbench Images')
+    .setObjectStoreName('__workbench_images__');
+
+  /** @private {!cwc.utils.Helper} */
+  this.loader_ = new cwc.addon.WorkbenchLoader(
+    helper,
+    this.projectsDb_,
+    this.imagesDb_);
+
+  /** @private {!Array<Element>} */
+  this.cards_ = [];
+
+  /** @private {!cwc.utils.Logger} */
+  this.log_ = new cwc.utils.Logger(this.name);
+};
+
+
+cwc.addon.Workbench.prototype.prepare = async function() {
+  if (!this.helper.experimentalEnabled()) {
+    return;
+  }
+
+  this.log_.info('Preparing Workbench addon...');
+
+  await this.projectsDb_.open();
+  await this.imagesDb_.open();
+  this.loader_.loadProjects();
+  this.loader_.onLoadComplete(() => this.showRelevantProjects_());
+
+  let selectScreenInstance = this.helper.getInstance('selectScreen');
+  if (selectScreenInstance) {
+    goog.events.listen(selectScreenInstance.getEventHandler(),
+      cwc.ui.SelectScreen.Events.Type.VIEW_CHANGE,
+      this.showRelevantProjects_, false, this);
+  }
+};
+
+
+cwc.addon.Workbench.prototype.getAllProjects_ = function() {
+  return new Promise((resolve) => {
+    this.projectsDb_.getAll().then((results) => {
+      const parsed = results.map((result) => JSON.parse(result));
+      resolve(parsed);
+    });
+  });
+};
+
+
+cwc.addon.Workbench.prototype.filterProjectsByTag_ = function(
+  projects, filterTag) {
+  return projects.filter((project) => (
+    project['theme_tags'].find((tag) => (
+      (tag.title || '').toLowerCase() === (filterTag || '').toLowerCase())
+    )
+  ));
+};
+
+
+cwc.addon.Workbench.prototype.showRelevantProjects_ = async function() {
+  const allProjects = await this.getAllProjects_();
+  this.clearCards_();
+
+  Object.keys(tagMap).forEach((tag) => {
+    const tabNode = document.querySelector(tagMap[tag].appendNode);
+    if (!tabNode) return;
+
+    const mode = tagMap[tag].mode;
+    const matchingProjects = this.filterProjectsByTag_(allProjects, tag);
+
+    matchingProjects.forEach((project) => {
+      const card = goog.soy.renderAsElement(
+        cwc.soy.SelectScreenTemplate.fileCard, {
+          title: project.name,
+          text: project.description,
+          opt_link_text: 'Start Project',
+          opt_color_class: 'bg-light-blue',
+          opt_icon: 'school',
+        });
+
+      card.addEventListener('click', () => {
+        this.helper.getInstance('mode')
+          .loadMode(mode)
+          .then(() => {
+            const projectUI = new cwc.addon.WorkbenchProject(
+              this.helper,
+              project,
+              this.imagesDb_,
+            );
+            projectUI.decorate();
+          });
+      });
+
+      tabNode.appendChild(card);
+      this.cards_.push(card);
+    });
+  });
+};
+
+
+cwc.addon.Workbench.prototype.clearCards_ = function() {
+  this.cards_.forEach((card) => card.remove());
+  this.cards_ = [];
+};

--- a/src/addon/workbench/workbench.js
+++ b/src/addon/workbench/workbench.js
@@ -129,12 +129,17 @@ cwc.addon.Workbench = function(helper) {
   this.helper = helper;
 
   /** @private {!cwc.utils.Database} */
-  this.projectsDb_ = new cwc.utils.Database('Workbench Projects')
+  this.projectsDb_ = new cwc.utils.Database('Workbench')
     .setObjectStoreName('__workbench_projects__');
 
   /** @private {!cwc.utils.Database} */
-  this.imagesDb_ = new cwc.utils.Database('Workbench Images')
+  this.imagesDb_ = new cwc.utils.Database('Workbench')
     .setObjectStoreName('__workbench_images__');
+
+  /** @private {!Object} */
+  this.databaseConfig_ = {
+    'objectStoreNames': ['__workbench_projects__', '__workbench_images__'],
+  };
 
   /** @private {!cwc.utils.Helper} */
   this.loader_ = new cwc.addon.WorkbenchLoader(
@@ -157,8 +162,8 @@ cwc.addon.Workbench.prototype.prepare = async function() {
 
   this.log_.info('Preparing Workbench addon...');
 
-  await this.projectsDb_.open();
-  await this.imagesDb_.open();
+  await this.projectsDb_.open(this.databaseConfig_);
+  await this.imagesDb_.open(this.databaseConfig_);
   this.loader_.loadProjects();
   this.loader_.onLoadComplete(() => this.showRelevantProjects_());
 

--- a/src/addon/workbench/workbench_loader.js
+++ b/src/addon/workbench/workbench_loader.js
@@ -70,7 +70,7 @@ cwc.addon.WorkbenchLoader.prototype.loadProjects = function() {
 
       if (projects && projects.length) {
         projects.forEach((project) => {
-          const dbKey = `project-${project.id}`;
+          const dbKey = project.id;
 
           this.projectsDb_.get(dbKey).then((storedProject) => {
             if (storedProject) {

--- a/src/addon/workbench/workbench_loader.js
+++ b/src/addon/workbench/workbench_loader.js
@@ -104,10 +104,21 @@ cwc.addon.WorkbenchLoader.prototype.loadProjects = function() {
  */
 cwc.addon.WorkbenchLoader.prototype.loadSingleProject_ = function(projectID,
     callback) {
+  const isDataCorrupt = (data = {}) => !(
+    data['name'] &&
+    data['steps'] &&
+    data['steps'].length &&
+    data['steps'].every((step) => step['description'])
+  );
+
   cwc.utils.Resources.getUriAsJson(this.projectsApiBase_ + projectID)
     .then((json) => {
-      callback(null, json);
-      this.downloadProjectMedia_(json);
+      if (isDataCorrupt(json)) {
+        callback(`project data for project with ID ${projectID} is corrupt`);
+      } else {
+        callback(null, json);
+        this.downloadProjectMedia_(json);
+      }
     })
     .catch(callback);
 };

--- a/src/addon/workbench/workbench_loader.js
+++ b/src/addon/workbench/workbench_loader.js
@@ -51,7 +51,7 @@ cwc.addon.WorkbenchLoader = function(helper, projectsDb, imagesDb) {
   this.loadCompleteListeners_ = [];
 
   /** @private {string} */
-  this.projectsApiBase_ = 'https://staging.cwist.com/api/v1/activities/';
+  this.projectsApiBase_ = 'https://edu.workbencheducation.com/api/v1/activities/';
 
   /** @private {string} */
   this.projectsApiAll_ = `${this.projectsApiBase_}?content_channels=1`;

--- a/src/addon/workbench/workbench_loader.js
+++ b/src/addon/workbench/workbench_loader.js
@@ -1,0 +1,186 @@
+/**
+ * @fileoverview Workbench addon project loader
+ *
+ * @license Copyright 2018 The Coding with Chrome Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author mdiehl@workbenchplatform.com (Matt Diehl)
+ */
+goog.provide('cwc.addon.WorkbenchLoader');
+
+goog.require('goog.net.XhrIo');
+goog.require('cwc.utils.Logger');
+
+
+/**
+ * @param {!cwc.utils.Helper} helper
+ * @param {!cwc.utils.Database} projectsDb
+ * @param {!cwc.utils.Database} imagesDb
+ * @constructor
+ * @struct
+ * @final
+ */
+cwc.addon.WorkbenchLoader = function(helper, projectsDb, imagesDb) {
+  /** @type {!string} */
+  this.name = 'WorkbenchLoader';
+
+  /** @private {!cwc.utils.Database} */
+  this.projectsDb_ = projectsDb;
+
+  /** @private {!cwc.utils.Database} */
+  this.imagesDb_ = imagesDb;
+
+  /** @type {!cwc.utils.Helper} */
+  this.helper = helper;
+
+  /** @private {!cwc.utils.Logger} */
+  this.log_ = new cwc.utils.Logger(this.name);
+
+  /** @private {!Array<Function>} */
+  this.loadCompleteListeners_ = [];
+
+  /** @private {string} */
+  this.projectsApiBase_ = 'https://staging.cwist.com/api/v1/activities/';
+
+  /** @private {string} */
+  this.projectsApiAll_ = `${this.projectsApiBase_}?content_channels=1`;
+};
+
+
+/**
+ * Loads projects from Workbench
+ */
+cwc.addon.WorkbenchLoader.prototype.loadProjects = function() {
+  if (!this.helper.checkFeature('online')) return;
+
+  let xhr = new goog.net.XhrIo();
+  goog.events.listen(xhr, goog.net.EventType.SUCCESS, (e) => {
+    let xhr = /** @type {!goog.net.XhrIo} */ (e.target);
+    let data = xhr.getResponseJson() || {};
+    let projects = data['results'];
+
+    if (projects && projects.length) {
+      projects.forEach(async (project) => {
+        const dbKey = `project-${project.id}`;
+
+        this.projectsDb_.get(dbKey).then((storedProject) => {
+          if (storedProject) {
+            storedProject = JSON.parse(storedProject);
+          }
+
+          if (!storedProject || (
+              storedProject &&
+              storedProject['modified'] !== project['modified'])) {
+            this.loadSingleProject_(project.id, (err, projectData) => {
+              if (err) {
+                // remove any project that fails to load
+                this.projectsDb_.delete(dbKey);
+                return;
+              }
+
+              this.projectsDb_.set(dbKey, JSON.stringify(projectData));
+            });
+          }
+        });
+      });
+    }
+  });
+  goog.events.listen(xhr, goog.net.EventType.ERROR, function() {
+    this.log_.warn('Unable to load projects');
+  });
+  xhr.send(this.projectsApiAll_);
+};
+
+
+/**
+ * Loads projects from Workbench
+ * @param {number} projectID
+ * @param {function(?string=, Object=)} callback
+ */
+cwc.addon.WorkbenchLoader.prototype.loadSingleProject_ = function(projectID,
+    callback) {
+  let xhr = new goog.net.XhrIo();
+  let projectsAPI = this.projectsApiBase_ + projectID;
+  goog.events.listen(xhr, goog.net.EventType.SUCCESS, (e) => {
+    let xhr = /** @type {!goog.net.XhrIo} */ (e.target);
+    let data = xhr.getResponseJson() || {};
+    callback(null, data);
+    this.downloadProjectMedia_(data);
+  });
+  goog.events.listen(xhr, goog.net.EventType.ERROR, function() {
+    callback(`Unable to load project with ID: ${projectID}`);
+  });
+  xhr.send(projectsAPI);
+};
+
+
+/**
+ * Download project media files
+ * @param {Object} projectData
+ */
+cwc.addon.WorkbenchLoader.prototype.downloadProjectMedia_ = function(
+  projectData) {
+  let images = (projectData['steps'] || []).reduce((acc, step) => {
+    return acc.concat(step.images);
+  }, []);
+  images.forEach((url) => {
+    this.imagesDb_.get(url).then((savedImage) => {
+      if (!savedImage) {
+        this.saveMediaLocal_(url);
+      }
+    });
+  });
+};
+
+
+/**
+ * Download project media files
+ * @param {string} url
+ */
+cwc.addon.WorkbenchLoader.prototype.saveMediaLocal_ = function(url) {
+  let fileReader = new FileReader();
+  let xhr = new goog.net.XhrIo();
+  fileReader.addEventListener('load', () => {
+    let dataURL = fileReader.result;
+    this.imagesDb_.set(url, dataURL);
+  });
+  xhr.setResponseType(goog.net.XhrIo.ResponseType.ARRAY_BUFFER);
+  goog.events.listen(xhr, goog.net.EventType.SUCCESS, (e) => {
+    let xhr = /** @type {!goog.net.XhrIo} */ (e.target);
+    let data = xhr.getResponse() || {};
+    let blob = new Blob([data], {type: 'image/png'});
+    fileReader.readAsDataURL(blob);
+  });
+  goog.events.listen(xhr, goog.net.EventType.ERROR, function() {
+    this.log_.warn(`Failed to download and save image: ${url}`);
+  });
+  xhr.send(url);
+};
+
+
+/**
+ * Fire all load complete listeners that were added
+ */
+cwc.addon.WorkbenchLoader.prototype.fireLoadCompleteListeners_ = function() {
+  this.loadCompleteListeners_.forEach((fn) => fn());
+};
+
+
+/**
+ * Add a function to be fired after projects have finished downloading
+ * @param {Function} fn
+ */
+cwc.addon.WorkbenchLoader.prototype.onLoadComplete = function(fn) {
+  this.loadCompleteListeners_.push(fn);
+};

--- a/src/addon/workbench/workbench_loader.js
+++ b/src/addon/workbench/workbench_loader.js
@@ -71,7 +71,7 @@ cwc.addon.WorkbenchLoader.prototype.loadProjects = function() {
     let projects = data['results'];
 
     if (projects && projects.length) {
-      projects.forEach(async (project) => {
+      projects.forEach((project) => {
         const dbKey = `project-${project.id}`;
 
         this.projectsDb_.get(dbKey).then((storedProject) => {

--- a/src/addon/workbench/workbench_loader.js
+++ b/src/addon/workbench/workbench_loader.js
@@ -62,7 +62,11 @@ cwc.addon.WorkbenchLoader = function(helper, projectsDb, imagesDb) {
  * Loads projects from Workbench
  */
 cwc.addon.WorkbenchLoader.prototype.loadProjects = function() {
-  if (!this.helper.checkFeature('online')) return;
+  const userConfigInstance = this.helper.getInstance('userConfig') || {};
+  const isFetchEnabled = userConfigInstance.get(cwc.userConfigType.GENERAL,
+    cwc.userConfigName.WORKBENCH_FETCH);
+
+  if (!this.helper.checkFeature('online') || !isFetchEnabled) return;
 
   cwc.utils.Resources.getUriAsJson(this.projectsApiAll_)
     .then((json) => {

--- a/src/addon/workbench/workbench_loader.js
+++ b/src/addon/workbench/workbench_loader.js
@@ -148,9 +148,9 @@ cwc.addon.WorkbenchLoader.prototype.downloadProjectMedia_ = function(
  * @param {string} url
  */
 cwc.addon.WorkbenchLoader.prototype.saveMediaLocal_ = function(url) {
-  cwc.utils.Resources.getUriAsBase64(url)
-    .then((dataUrl) => {
-      this.imagesDb_.set(url, dataUrl);
+  cwc.utils.Resources.getUriAsBlob(url)
+    .then((blob) => {
+      this.imagesDb_.set(url, blob);
     });
 };
 

--- a/src/addon/workbench/workbench_project.gss
+++ b/src/addon/workbench/workbench_project.gss
@@ -1,0 +1,236 @@
+/**
+ * Copyright 2018 The Coding with Chrome Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+
+#{$prefix}wb-container {
+  bottom: 0;
+  left: 0;
+  overflow-y: auto;
+  padding: 16px;
+  position: absolute;
+  right: 0;
+  top: 34px;
+}
+
+#{$prefix}wb-description {
+  margin-top: 24px;
+}
+
+#{$prefix}wb-steps {
+  counter-reset: step-number;
+  list-style: none;
+  margin-top: 36px;
+  padding-left: 0;
+}
+
+.{$prefix}wb-step-actions {
+  margin-top: 24px;
+}
+
+.{$prefix}wb-step-container {
+  counter-increment: step-number;
+  padding-bottom: 20px;
+  padding-left: 36px;
+  position: relative;
+}
+
+/* Rich text cleanup */
+.{$prefix}wb-step-description br:last-child,
+.{$prefix}wb-step-description blockquote::after,
+.{$prefix}wb-step-description blockquote::before {
+  display: none; /* material css was applying broken pseudo content */
+}
+
+.{$prefix}wb-step-container--active {
+  padding-bottom: 48px;
+}
+
+.{$prefix}wb-step-container--complete:not(.{$prefix}wb-step-container--active) {
+  cursor: pointer;
+}
+
+.{$prefix}wb-step-content {
+  display: none;
+}
+
+.{$prefix}wb-step-media {
+  margin-top: 24px;
+  overflow-y: auto;
+  white-space: nowrap;
+}
+
+.{$prefix}wb-step-media:empty {
+  display: none;
+}
+
+.{$prefix}wb-step-media-expand {
+  -webkit-appearance: none;
+  border: 0;
+  border-radius: none;
+  cursor: pointer;
+  display: inline-block;
+  margin-right: 4px;
+  padding: 0;
+  position: relative;
+  vertical-align: middle;
+}
+
+.{$prefix}wb-step-media-expand i {
+  color: #fff;
+  font-size: 48px;
+  left: 50%;
+  opacity: .25;
+  position: absolute;
+  text-shadow: 0 0 8px rgba(0, 0, 0, .75);
+  top: 50%;
+  transform: translate(-50%, -50%);
+  transition: opacity 400ms;
+}
+
+.{$prefix}wb-step-media-expand:hover i {
+  opacity: 1;
+}
+
+.{$prefix}wb-step-media-item {
+  display: block;
+  height: 144px;
+  width: auto;
+}
+
+.{$prefix}wb-step-media-item-video {
+  background-color: #949394;
+  padding-bottom: 56.25%;
+  position: relative;
+  width: 144px;
+}
+
+.{$prefix}wb-step-media-item-video i {
+  color: #fff;
+  left: 50%;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  position: absolute;
+}
+
+.{$prefix}wb-step-container--active .{$prefix}wb-step-content {
+  display: block;
+}
+
+.{$prefix}wb-step-number {
+  background-color: #949394;
+  border-radius: 50%;
+  color: #FFF;
+  content: counter(step-number);
+  font-size: 12px;
+  left: 0;
+  line-height: 24px;
+  height: 24px;
+  position: absolute;
+  text-align: center;
+  top: 0;
+  width: 24px;
+}
+
+.{$prefix}wb-step-number-check {
+  display: none;
+}
+
+.{$prefix}wb-step-container--complete .{$prefix}wb-step-number-check {
+  display: inline;
+}
+
+.{$prefix}wb-step-container--complete .{$prefix}wb-step-number-text {
+  display: none;
+}
+
+.{$prefix}wb-step-container--active .{$prefix}wb-step-number,
+.{$prefix}wb-step-container--complete .{$prefix}wb-step-number {
+  background-color: rgb(63,81,181);
+}
+
+.{$prefix}wb-step-container::before {
+  border-left: 1px solid #E0DFE0;
+  bottom: 10px;
+  content: '';
+  left: 12px;
+  position: absolute;
+  top: 36px;
+}
+
+.{$prefix}wb-step-container:last-child::before {
+  display: none;
+}
+
+.{$prefix}wb-step-title {
+  color: rgba(0, 0, 0, .38);
+  font-weight: 400;
+  margin: 0 0 24px;
+}
+
+.{$prefix}wb-step-container--active .{$prefix}wb-step-title {
+  color: rgba(0, 0, 0, .87);
+  font-weight: 700;
+}
+
+#{$prefix}wb-toolbar-chrome .mdl-layout__header-row {
+  height: 34px;
+  justify-content: flex-end;
+}
+
+#{$prefix}wb-toolbar-chrome .mdl-layout__header-row .mdl-navigation__link {
+  padding: 0 5px;
+}
+
+#{$prefix}wb-url {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+
+#{$prefix}wb-media-overlay {
+  align-items: center;
+  background-color: #000;
+  bottom: 0;
+  display: flex;
+  justify-content: center;
+  left: 0;
+  position: fixed;
+  right: 0;
+  top: 34px; /* height of header */
+}
+
+#{$prefix}wb-media-overlay.is-hidden {
+  display: none;
+}
+
+#{$prefix}wb-media-overlay-content img,
+#{$prefix}wb-media-overlay-content webview {
+  max-height: 90vh;
+  max-width: 90vw;
+}
+
+#{$prefix}wb-media-overlay webview {
+  height: 750px;
+  width: 1000px;
+}
+
+#{$prefix}wb-media-overlay-close {
+  color: #fff;
+  left: 16px;
+  position: absolute;
+  top: 16px;
+}

--- a/src/addon/workbench/workbench_project.gss
+++ b/src/addon/workbench/workbench_project.gss
@@ -218,11 +218,17 @@
 }
 
 #{$prefix}wb-media-overlay-content img,
+#{$prefix}wb-media-overlay-content video,
 #{$prefix}wb-media-overlay-content webview {
   max-height: 90vh;
   max-width: 90vw;
 }
 
+#{$prefix}wb-media-overlay video::-webkit-media-controls-fullscreen-button {
+  display: none;
+}
+
+#{$prefix}wb-media-overlay video,
 #{$prefix}wb-media-overlay webview {
   height: 750px;
   width: 1000px;

--- a/src/addon/workbench/workbench_project.js
+++ b/src/addon/workbench/workbench_project.js
@@ -1,0 +1,335 @@
+/**
+ * @fileoverview Workbench addon project display
+ *
+ * @license Copyright 2018 The Coding with Chrome Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author mdiehl@workbenchplatform.com (Matt Diehl)
+ */
+goog.provide('cwc.addon.WorkbenchProject');
+
+goog.require('soydata.VERY_UNSAFE');
+goog.require('cwc.soy.addon.WorkbenchProject');
+goog.require('goog.html.SafeHtml');
+goog.require('goog.html.sanitizer.HtmlSanitizer');
+
+
+/**
+ * @param {!cwc.utils.Helper} helper
+ * @param {!object} project
+ * @param {!cwc.utils.Database} imagesDb
+ * @constructor
+ * @struct
+ * @final
+ */
+cwc.addon.WorkbenchProject = function(helper, project, imagesDb) {
+  /** @type {string} */
+  this.name = 'WorkbenchProject';
+
+  /** @type {!cwc.utils.Helper} */
+  this.helper = helper;
+
+  /** @private {!cwc.utils.Database} */
+  this.imagesDb_ = imagesDb;
+
+  /** @type {string} */
+  this.prefix = this.helper.getPrefix('wb');
+
+  /** @private {!string} */
+  this.projectDetailLinkBase_ = 'https://edu.workbencheducation.com/cwists/preview/';
+
+  /** @private {!string} */
+  this.activeStepClass_ = this.prefix + 'step-container--active';
+
+  /** @private {!string} */
+  this.completedStepClass_ = this.prefix + 'step-container--complete';
+
+  /** @private {!Element} */
+  this.nodeMediaOverlay_ = null;
+
+  /** @private {!Element} */
+  this.nodeMediaOverlayClose_ = null;
+
+  /** @private {!Element} */
+  this.nodeMediaOverlayContent_ = null;
+
+  /** @type {Object} */
+  this.project = project;
+
+  /** @private {Array<Object>} */
+  this.steps_ = [];
+
+  /** @private {!Object} */
+  this.state_ = {};
+
+  /** @private {!boolean} */
+  this.webviewSupport_ = this.helper.checkChromeFeature('webview');
+};
+
+
+/**
+ * Adds the project to the current canvas sidebar
+ */
+cwc.addon.WorkbenchProject.prototype.decorate = function() {
+  if (!this.project) return;
+
+  const sanitizer = new goog.html.sanitizer.HtmlSanitizer();
+  const sidebarInstance = this.helper.getInstance('sidebar');
+  const templateData = {
+    prefix: this.prefix,
+    description: this.project.description,
+    online: this.helper.checkFeature('online'),
+    url: this.projectDetailLinkBase_ + this.project.id,
+    steps: this.project['steps'].map((step, index) => ({
+      id: step.id,
+      description: soydata.VERY_UNSAFE.ordainSanitizedHtml(
+        goog.html.SafeHtml.unwrap(
+          sanitizer.sanitize(step.description)
+        )
+      ),
+      images: step.images,
+      number: index + 1,
+      title: step.title || `Step ${index + 1}`,
+      videos: (step['videos'] || []).map((video) => video['youtube_id']),
+    })),
+  };
+
+  const showProjectInSidebar = () => {
+    sidebarInstance.showTemplateContent(
+      'workbench_project',
+      this.project.name,
+      cwc.soy.addon.WorkbenchProject.template,
+      templateData
+    );
+  };
+
+  if (sidebarInstance) {
+    sidebarInstance.addCustomButton(
+      'workbench_project',
+      'format_list_numbered',
+      'show project',
+      () => {
+        showProjectInSidebar();
+        this.initUI_();
+        this.updateView_();
+      }
+    );
+
+    showProjectInSidebar();
+  }
+
+  this.state_ = {
+    completedSteps: [],
+    activeStepID: null,
+    inProgressStepID: null,
+  };
+
+  this.initUI_();
+};
+
+
+/**
+ * Actions that happen after the template is rendered:
+ * add event listeners, show active step, render images from DB
+ */
+cwc.addon.WorkbenchProject.prototype.initUI_ = function() {
+  const rootNode = goog.dom.getElement(this.prefix + 'container');
+  const nodeListImages = rootNode.querySelectorAll('.js-project-step-image');
+  this.nodeMediaOverlay_ = goog.dom.getElement(this.prefix + 'media-overlay');
+  this.nodeMediaOverlayClose_ = goog.dom.getElement(
+    this.prefix + 'media-overlay-close');
+  this.nodeMediaOverlayContent_ = goog.dom.getElement(
+    this.prefix + 'media-overlay-content');
+
+  this.nodeMediaOverlayClose_.addEventListener('click', () => {
+    this.setState_({
+      expandedMedia: null,
+    });
+  });
+
+  this.steps_ = this.project['steps'].map((step) => {
+    const stepNode = goog.dom.getElement(this.prefix + 'step-' + step.id);
+    return {
+      id: step.id,
+      node: stepNode,
+      nodeContinue: stepNode.querySelector(
+        '.js-project-step-continue'),
+      nodeHeader: stepNode.querySelector(
+        '.js-project-step-header'),
+      nodeListMediaExpand: stepNode.querySelectorAll(
+        '.js-project-step-media-expand'),
+    };
+  });
+
+  [].forEach.call(nodeListImages, (image) => {
+    let imageSrc = image.getAttribute('data-src');
+    this.imagesDb_.get(imageSrc).then((imageData) => {
+      if (imageData) {
+        image.setAttribute('src', imageData);
+      } else {
+        image.remove();
+      }
+    });
+  });
+
+  this.steps_.forEach((step) => {
+    if (step.nodeContinue) {
+      goog.events.listen(step.nodeContinue, goog.events.EventType.CLICK,
+        this.completeCurrentStep_.bind(this));
+    }
+    goog.events.listen(step.nodeHeader, goog.events.EventType.CLICK,
+      this.jumpToStep_.bind(this, step.id));
+
+    [].forEach.call(step.nodeListMediaExpand, (toggle) => {
+      goog.events.listen(toggle, goog.events.EventType.CLICK,
+        this.onMediaClick_.bind(this, toggle));
+    });
+  });
+
+  this.setState_({
+    activeStepID: this.state_.activeStepID || this.steps_[0].id,
+  });
+};
+
+
+/**
+ * Marks the current step complete and opens the next
+ */
+cwc.addon.WorkbenchProject.prototype.completeCurrentStep_ = function() {
+  let completedSteps = this.state_.completedSteps.slice();
+  let currentStepIndex = this.steps_.findIndex((step) =>
+    step.id === this.state_.activeStepID);
+  let nextStep = this.steps_[currentStepIndex + 1] || {};
+  if (!completedSteps.includes(this.state_.activeStepID)) {
+    completedSteps.push(this.state_.activeStepID);
+  }
+  this.setState_({
+    completedSteps: completedSteps,
+    activeStepID: nextStep.id,
+    inProgressStepID: nextStep.id,
+  });
+};
+
+
+/**
+ * Opens a step, but only if it is complete or next
+ * @param {!number} stepID
+ */
+cwc.addon.WorkbenchProject.prototype.jumpToStep_ = function(stepID) {
+  let canOpen = stepID === this.state_.inProgressStepID ||
+    this.state_.completedSteps.includes(stepID);
+  if (canOpen) {
+    this.setState_({
+      activeStepID: stepID,
+    });
+  }
+};
+
+
+/**
+ * Shows media in a full screen overlay
+ * @param {Element} button
+ */
+cwc.addon.WorkbenchProject.prototype.onMediaClick_ = function(button) {
+  let mediaType = button.getAttribute('data-media-type');
+  let mediaImg = button.querySelector('img');
+  let youtubeId = button.getAttribute('data-youtube-id');
+
+  if (mediaType === 'image' && mediaImg) {
+    let clone = mediaImg.cloneNode(true);
+    clone.removeAttribute('class');
+    this.setState_({
+      expandedMedia: clone,
+    });
+  } else if (mediaType === 'youtube' && youtubeId) {
+    let content = document.createElement(
+      this.webviewSupport_ ? 'webview' : 'iframe');
+    content.src = `https://www.youtube-nocookie.com/embed/${youtubeId}/?rel=0&amp;autoplay=0&showinfo=0`;
+
+    this.setState_({
+      expandedMedia: content,
+    });
+  }
+};
+
+
+/**
+ * Event fired on media overlay close button click
+ */
+cwc.addon.WorkbenchProject.prototype.onMediaClose_ = function() {
+  this.setState_({
+    expandedMedia: null,
+  });
+};
+
+
+/**
+ * Closes media overlay
+ */
+cwc.addon.WorkbenchProject.prototype.hideMedia_ = function() {
+  while (this.nodeMediaOverlayContent_.firstChild) {
+    this.nodeMediaOverlayContent_.firstChild.remove();
+  }
+  this.nodeMediaOverlay_.classList.add('is-hidden');
+};
+
+
+/**
+ * Shows media overlay with the provided element
+ * @param {!Element} media
+ */
+cwc.addon.WorkbenchProject.prototype.showMedia_ = function(media) {
+  this.nodeMediaOverlayContent_.appendChild(media);
+  this.nodeMediaOverlay_.classList.remove('is-hidden');
+};
+
+
+/**
+ * Updates the current state, then triggers a view update
+ * @param {!Object} change
+ */
+cwc.addon.WorkbenchProject.prototype.setState_ = function(change) {
+  Object.keys(change).forEach((key) => {
+    this.state_[key] = change[key];
+  });
+  this.updateView_();
+};
+
+
+/**
+ * Updates the view to reflect the current state
+ */
+cwc.addon.WorkbenchProject.prototype.updateView_ = function() {
+  this.steps_.forEach((step) => {
+    // active step
+    if (step.id === this.state_.activeStepID) {
+      step.node.classList.add(this.activeStepClass_);
+    } else {
+      step.node.classList.remove(this.activeStepClass_);
+    }
+
+    // completed steps
+    if (this.state_.completedSteps.includes(step.id)) {
+      step.node.classList.add(this.completedStepClass_);
+    } else {
+      step.node.classList.remove(this.completedStepClass_);
+    }
+  });
+
+  if (this.state_.expandedMedia) {
+    this.showMedia_(this.state_.expandedMedia);
+  } else {
+    this.hideMedia_();
+  }
+};

--- a/src/addon/workbench/workbench_project.soy
+++ b/src/addon/workbench/workbench_project.soy
@@ -1,0 +1,108 @@
+/**
+ * @fileoverview Workbench project template for Coding with Chrome editor.
+ *
+ * @license Copyright 2018 The Coding with Chrome Authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * @author mdiehl@workbenchplatform.com (Matt Diehl)
+ */
+{namespace cwc.soy.addon.WorkbenchProject autoescape="strict"}
+
+/**
+ * Main HTML template for the editor.
+ */
+{template .template}
+  {@param description: string}
+  {@param online: bool}
+  {@param prefix: string}
+  {@param steps: list<?>}
+  {@param url: string}
+
+  <div id="{$prefix}container">
+    <div id="{$prefix}url" class="mdl-typography--caption">
+      Full Project: <a href="{$url}" target="_blank" noreferrer noopener>{$url}</a>
+    </div>
+    <div id="{$prefix}description">
+      <p>{$description}</p>
+    </div>
+    <ol id="{$prefix}steps">
+      {foreach $step in $steps}
+        {call .step_ data="$step"}
+          {param online: $online /}
+          {param prefix: $prefix + 'step-' /}
+          {param isLastStep: isLast($step) /}
+        {/call}
+      {/foreach}
+    </ol>
+    <div id="{$prefix}media-overlay">
+      <button type="button" id="{$prefix}media-overlay-close" class="mdl-button mdl-js-button mdl-button--icon">
+        <i class="material-icons">arrow_back</i>
+      </button>
+      <div id="{$prefix}media-overlay-content"></div>
+    </div>
+  </div>
+{/template}
+
+
+/**
+ * Step
+ */
+{template .step_}
+  {@param description: string}
+  {@param id: int}
+  {@param images: list<string>}
+  {@param isLastStep: bool}
+  {@param number: number}
+  {@param online: bool}
+  {@param prefix: string}
+  {@param title: string}
+  {@param videos: list<string>}
+
+  <li id="{$prefix}{$id}" class="{$prefix}container js-project-step">
+    <div class="{$prefix}header js-project-step-header">
+      <div class="{$prefix}number">
+        <span class="{$prefix}number-text">{$number}</span>
+        <span class="{$prefix}number-check">
+          <i class="material-icons">checkmark</i>
+        </span>
+      </div>
+      <div class="{$prefix}title">{$title}</div>
+    </div>
+    <div class="{$prefix}content">
+      <div class="{$prefix}description">{$description}</div>
+      <div class="{$prefix}media">
+        {foreach $image in $images}
+          <button type="button" class="{$prefix}media-expand js-project-step-media-expand" title="Expand image" data-media-type="image">
+            <img data-src="{$image}" alt="" class="{$prefix}media-item js-project-step-image">
+            <i class="material-icons">fullscreen</i>
+          </button>
+        {/foreach}
+        {if $online}
+          {foreach $video in $videos}
+            <button type="button" class="{$prefix}media-expand {$prefix}media-expand js-project-step-media-expand" title="Expand video" data-media-type="youtube" data-youtube-id="{$video}">
+              <div class="{$prefix}media-item-video">
+                <i class="material-icons">play_circle_outline</i>
+              </div>
+            </button>
+          {/foreach}
+        {/if}
+      </div>
+      {if not $isLastStep}
+        <div class="{$prefix}actions">
+          <button type="button" class="mdl-button mdl-js-button mdl-button--colored mdl-button--raised js-project-step-continue">Continue</button>
+        </div>
+      {/if}
+    </div>
+  </li>
+{/template}

--- a/src/addon/workbench/workbench_project.soy
+++ b/src/addon/workbench/workbench_project.soy
@@ -68,6 +68,7 @@
   {@param prefix: string}
   {@param title: string}
   {@param videos: list<string>}
+  {@param youtube_videos: list<string>}
 
   <li id="{$prefix}{$id}" class="{$prefix}container js-project-step">
     <div class="{$prefix}header js-project-step-header">
@@ -88,8 +89,15 @@
             <i class="material-icons">fullscreen</i>
           </button>
         {/foreach}
+        {foreach $video in $videos}
+          <button type="button" class="{$prefix}media-expand {$prefix}media-expand js-project-step-media-expand" title="Expand video" data-media-type="video" data-video-url="{$video}">
+            <div class="{$prefix}media-item-video">
+              <i class="material-icons">play_circle_outline</i>
+            </div>
+          </button>
+        {/foreach}
         {if $online}
-          {foreach $video in $videos}
+          {foreach $video in $youtube_videos}
             <button type="button" class="{$prefix}media-expand {$prefix}media-expand js-project-step-media-expand" title="Expand video" data-media-type="youtube" data-youtube-id="{$video}">
               <div class="{$prefix}media-item-video">
                 <i class="material-icons">play_circle_outline</i>

--- a/src/config/user_config.js
+++ b/src/config/user_config.js
@@ -55,6 +55,7 @@ cwc.userConfigName = {
   PYTHON: 'python',
   SKIP_WELCOME: 'skip_welcome',
   SPHERO: 'sphero',
+  WORKBENCH_FETCH: 'workbench_fetch',
   ZOOM: 'zoom',
 };
 

--- a/src/mode/modder.js
+++ b/src/mode/modder.js
@@ -64,11 +64,12 @@ cwc.mode.Modder = function(helper) {
 
 /**
  * @param {cwc.mode.Type} mode
+ * @return {!Promise}
  */
 cwc.mode.Modder.prototype.loadMode = function(mode) {
   let modeConfig = cwc.mode.Config.get(mode);
   let loaderInstance = this.helper.getInstance('fileLoader', true);
-  loaderInstance.loadLocalFile(this.templatePath_ + modeConfig.template);
+  return loaderInstance.loadLocalFile(this.templatePath_ + modeConfig.template);
 };
 
 

--- a/src/ui/builder.js
+++ b/src/ui/builder.js
@@ -25,6 +25,7 @@ goog.provide('cwc.ui.BuilderHelpers');
 goog.require('cwc.Cache');
 goog.require('cwc.UserConfig');
 goog.require('cwc.addon.Message');
+goog.require('cwc.addon.Workbench');
 goog.require('cwc.config');
 goog.require('cwc.fileHandler.File');
 goog.require('cwc.fileHandler.FileExporter');
@@ -81,6 +82,7 @@ goog.require('goog.dom');
  */
 cwc.ui.Addons = {
   'message': cwc.addon.Message,
+  'workbench': cwc.addon.Workbench,
 };
 
 

--- a/src/ui/select_screen/normal/basic/basic.soy
+++ b/src/ui/select_screen/normal/basic/basic.soy
@@ -84,12 +84,12 @@
   {/call}
 
   {if $experimental}
-    <div id="tutorial-basic-content">
+    <div id="tour-basic-content">
       {call cwc.soy.SelectScreenTemplate.titleGrid data="all"}
         {param text: 'Select a Tour ...' /}
         {param opt_icon: 'library_books' /}
       {/call}
-  
+
       <div class="mdl-grid">
         {call cwc.soy.SelectScreenTemplate.fileCard data="all"}
           {param title: 'Coding with Chrome Basics' /}
@@ -117,7 +117,7 @@
         {param opt_icon: 'school' /}
       {/call}
 
-      <div class="mdl-grid">
+      <div class="mdl-grid cwc-tutorial-list">
         {call cwc.soy.SelectScreenTemplate.fileCard data="all"}
           {param title: 'Blockly Basics' /}
           {param text: 'Learn drag-and-drop programming' /}

--- a/src/ui/setting_screen/setting_screen.js
+++ b/src/ui/setting_screen/setting_screen.js
@@ -156,6 +156,8 @@ cwc.ui.SettingScreen.prototype.setUserConfig = function() {
     cwc.userConfigName.EXPERIMENTAL_MODE);
   this.setConfig_('debug-mode', cwc.userConfigType.GENERAL,
     cwc.userConfigName.DEBUG_MODE);
+  this.setConfig_('workbench-fetch', cwc.userConfigType.GENERAL,
+    cwc.userConfigName.WORKBENCH_FETCH);
 };
 
 

--- a/src/ui/setting_screen/setting_screen.soy
+++ b/src/ui/setting_screen/setting_screen.soy
@@ -349,6 +349,14 @@
           {param id: 'experimental-mode' /}
           {param opt_restart: true /}
         {/call}
+
+        {call .setting_ data="all"}
+          {param title: 'Fetch new tutorials from Workbench' /}
+          {param text: 'New projects that are available from Workbench will be downloaded every time the application is restarted.' /}
+          {param type: 'switch' /}
+          {param id: 'workbench-fetch' /}
+          {param opt_restart: true /}
+        {/call}
       </ul>
 
       <div class="mdl-card__supporting-text">

--- a/src/utils/database.js
+++ b/src/utils/database.js
@@ -233,6 +233,24 @@ cwc.utils.Database.prototype.getAllWithKeys = async function(group, query,
 
 
 /**
+ * @param {!string} name
+ * @param {string=} group
+ * @return {Promise}
+ */
+cwc.utils.Database.prototype.delete = function(name, group) {
+  return new Promise((resolve, reject) => {
+    let result = this.getObjectStore_(group)['delete'](name);
+    result['onsuccess'] = (e) => {
+      resolve(e.target.result);
+    };
+    result['onerror'] = (e) => {
+      reject(e);
+    };
+  });
+};
+
+
+/**
  * @param {!string} objectStoreName
  * @return {THIS}
  * @template THIS

--- a/src/utils/resources.js
+++ b/src/utils/resources.js
@@ -107,6 +107,24 @@ cwc.utils.Resources.getUriAsJavaScriptTag = function(uri, nodeId) {
 
 
 /**
+ * @param {!string} uri
+ * @return {Promise}
+ * @private
+ */
+cwc.utils.Resources.getUriAsJson = function(uri) {
+  return new Promise((resolve, reject) => {
+    let xhr = new goog.net.XhrIo();
+    goog.events.listen(xhr, goog.net.EventType.SUCCESS, function(e) {
+      let xhrResponse = /** @type {!goog.net.XhrIo} */ (e.target);
+      resolve(xhrResponse.getResponseJson() || {});
+    });
+    cwc.utils.Resources.addXhrErrorEvents_(xhr, reject, uri);
+    xhr.send(uri);
+  });
+};
+
+
+/**
  * @param {!goog.net.XhrIo} xhr
  * @param {!Function} reject
  * @param {string=} uri


### PR DESCRIPTION
@MarkusBordihn, @adamcarheden, @MartenvanWezel 

This PR is a reimplementation of the CwC/Workbench integration from #132 that keeps all of the logic in an addon. Two demo projects can be found in the Beginner > Blockly section, after enabling experimental mode.

Some notes:

1. This is currently pulling projects from a staging site for testing purposes.
2. Workbench projects are appended to a given section if the project has a matching tag. I'm appending the projects to the current "tutorials" section, since I wasn't sure if there was sense in distinguishing Workbench projects from the other tutorials on the site, and, if we did, how to distinguish them. If we go with this approach, every section in CwC will need that section for this addon to append to (it currently searches for a div with class "cwc-tutorial-list" in each section).
3. To utilize the same tutorial button on the sidebar would have required changes to the sidebar component, so I instead added another section via the sidebar's ```addCustomButton``` method. I'm not sure how you all feel about this. Perhaps this is an alright approach, but in the projects listing, we should put Workbench projects in their own section?
4. I didn't dig into it too much, but the custom sidebar button tooltip isn't working for me.
5. I used the new database utility for storing projects and project images - is this the correct usage? I saw there's also a cache utility, but I wasn't clear on when that one should be used. Also, I added a delete method to the database utility.
6. The app is missing a "mode" for the Sphero BB8 robot.
7. I created a media overlay that I think is better suited to images, and is in line with the Material Design guidelines, instead of attempting to utilize the dialog component. It is all self-contained in the addon. Let me know if you disagree with this approach and I can rework it.
8. I updated the ```loadMode``` method in src/mode/modder.js to return a promise so I could use the sidebar after it was rendered.