### PR TITLE
Make debug version use third-party cwc libs

### DIFF
--- a/build/cwc/main-debug.js
+++ b/build/cwc/main-debug.js
@@ -31,8 +31,7 @@ closureBuilder.build({
     'gensoyfiles/**/!(*_test).js',
     '!src/{blocks,blocks/**.js}',
     '!src/{frameworks,frameworks/**.js}',
-    '../coding-with-chrome-libraries/src/**/!(*_test).js',
-    // 'third_party/coding-with-chrome-libraries/src/**/!(*_test).js',
+     'third_party/coding-with-chrome-libraries/src/**/!(*_test).js',
   ]),
   externs: [
     'build/externs/blockly.js',


### PR DESCRIPTION
`npm run chrom-app-debug` is broken for me in master. I suspect the problem is that this change was made in build/cwc/main.js but not in build/cwc/main-debug.js.