### PR TITLE
Added write_line to simple framework

### DIFF
--- a/src/blocks/simple/blocks.js
+++ b/src/blocks/simple/blocks.js
@@ -39,6 +39,24 @@ Blockly.Blocks['simple_text_write'] = {
 
 
 /**
+ * Write line.
+ */
+Blockly.Blocks['simple_text_writeLine'] = {
+  init: function() {
+    this.setHelpUrl('');
+    this.setColour(290);
+    this.appendValueInput('text')
+      .setCheck('String')
+      .appendField(i18t('writeLine('));
+    this.appendDummyInput()
+      .appendField(')');
+    this.setPreviousStatement(true, ['Number', 'String']);
+    this.setNextStatement(true, ['Number', 'String']);
+    this.setTooltip(i18t('Writes the text on its own line the screen.'));
+  },
+};
+
+/**
  * Draw circle.
  */
 Blockly.Blocks['simple_draw_circle'] = {

--- a/src/blocks/simple/javascript.js
+++ b/src/blocks/simple/javascript.js
@@ -30,6 +30,16 @@ Blockly.JavaScript['simple_text_write'] = function(block) {
   return 'command.write(' + text + ');\n';
 };
 
+/**
+ * Write line.
+ * @param {!Blockly.block} block
+ * @return {string}
+ */
+Blockly.JavaScript['simple_text_writeLine'] = function(block) {
+  let text = Blockly.JavaScript.valueToCode(block, 'text',
+      Blockly.JavaScript.ORDER_ATOMIC);
+  return 'command.writeLine(' + text + ');\n';
+};
 
 /**
  * Draw circle.

--- a/src/blocks/simple/toolbox.soy
+++ b/src/blocks/simple/toolbox.soy
@@ -32,6 +32,11 @@
           <block type="text"><field name="TEXT"></field></block>
         </value>
       </block>
+      <block type="simple_text_writeLine">
+        <value name="text">
+          <block type="text"><field name="TEXT"></field></block>
+        </value>
+      </block>
     </category>
 
     <category name="Draw" colour="260">

--- a/src/config/config.js
+++ b/src/config/config.js
@@ -119,4 +119,4 @@ cwc.config.Sample = {
 /**
  * @return {string}
  */
-cwc.config.Version = '5.7.28';
+cwc.config.Version = '5.7.29';

--- a/src/frameworks/simple/command.js
+++ b/src/frameworks/simple/command.js
@@ -59,6 +59,15 @@ cwc.framework.simple.Command.prototype.write = function(text) {
   this.addNode_(goog.dom.createTextNode(text));
 };
 
+/**
+ * Writes a text and line break on screen.
+ * @param {string} text
+ * @export
+ */
+cwc.framework.simple.Command.prototype.writeLine = function(text) {
+  this.addNode_(goog.dom.createTextNode(text));
+  this.addNode_(goog.dom.createElement('br'));
+};
 
 /**
  * @param {string} title
@@ -105,6 +114,7 @@ cwc.framework.simple.Command.prototype.mapGlobal = function() {
   }
   window['command'] = {
     'write': this.write.bind(this),
+    'writeLine': this.writeLine.bind(this),
     'showAlert': this.showAlert.bind(this),
     'showPrompt': this.showPrompt.bind(this),
     'showActionCancel': this.showActionCancel.bind(this),


### PR DESCRIPTION
@MarkusBordihn 

Any objections to a write_line function in the Simple framework? I don't think there's a way to do this with the write() function alone.

I'd like to implement validation of student's code by simple matching the text output of the teacher's code exactly. That's easy with text, but text ends up being difficult to read without line breaks.