### PR TITLE
Prompt before loading tutorial example code

### DIFF
--- a/src/mode/modder.js
+++ b/src/mode/modder.js
@@ -76,6 +76,7 @@ cwc.mode.Modder.prototype.loadMode = function(mode) {
 /**
  * @param {cwc.mode.Type} mode
  * @return {!Promise}
+ * @export
  */
 cwc.mode.Modder.prototype.setMode = function(mode) {
   let modeConfig = cwc.mode.Config.get(mode);
@@ -187,6 +188,7 @@ cwc.mode.Modder.prototype.setFilename = function(filename) {
 
 /**
  * @param {cwc.mode.Type=} mode
+ * @export
  */
 cwc.mode.Modder.prototype.postMode = function(mode = this.mode) {
   this.log_.info('Post handling for', mode);
@@ -285,6 +287,7 @@ cwc.mode.Modder.prototype.addBlocklyView = function(name, content) {
  * @param {string=} content
  * @param {cwc.ui.EditorType=} type
  * @param {cwc.ui.EditorHint=} hints
+ * @export
  */
 cwc.mode.Modder.prototype.addEditorView = function(name, content, type, hints) {
   let editorInstance = this.helper.getInstance('editor');
@@ -296,6 +299,7 @@ cwc.mode.Modder.prototype.addEditorView = function(name, content, type, hints) {
 
 /**
  * @param {string} name
+ * @export
  */
 cwc.mode.Modder.prototype.setEditorView = function(name) {
   let editorInstance = this.helper.getInstance('editor');

--- a/src/ui/editor/editor.js
+++ b/src/ui/editor/editor.js
@@ -306,6 +306,7 @@ cwc.ui.Editor.prototype.setLocalHints = function(hints) {
 /**
  * @param {string=} name
  * @return {Object|string}
+ * @export
  */
 cwc.ui.Editor.prototype.getEditorContent = function(name) {
   let editorContent = {};
@@ -330,6 +331,7 @@ cwc.ui.Editor.prototype.getEditorContent = function(name) {
 /**
  * @param {string} content
  * @param {string=} view
+ * @export
  */
 cwc.ui.Editor.prototype.setEditorContent = function(content,
     view = cwc.ui.EditorContent.DEFAULT) {
@@ -502,6 +504,7 @@ cwc.ui.Editor.prototype.getViews = function() {
 
 /**
  * @return {string}
+ * @export
  */
 cwc.ui.Editor.prototype.getCurrentView = function() {
   return this.currentEditorView;

--- a/src/ui/tutorial/tutorial.gss
+++ b/src/ui/tutorial/tutorial.gss
@@ -18,10 +18,6 @@
  */
 
 
-#{$prefix}addon-tutorial-content h3 {
-  margin: 10px;
-}
-
 .{$prefix}tutorial-step-message {
   color: #ffffff;
   text-align: center;
@@ -65,6 +61,9 @@
   margin-top: 24px;
 }
 
+.{$prefix}tutorial-step-actions button {
+  margin-right: 0.5em
+}
 .{$prefix}tutorial-step-container {
   counter-increment: step-number;
   padding-bottom: 20px;

--- a/src/ui/tutorial/tutorial.soy
+++ b/src/ui/tutorial/tutorial.soy
@@ -76,6 +76,7 @@
   {@param id: int}
   {@param images: list<string>}
   {@param isLastStep: bool}
+  {@param hasCode: bool}
   {@param number: number}
   {@param online: bool}
   {@param prefix: string}
@@ -83,8 +84,8 @@
   {@param videos: list<string>}
   {@param youtube_videos: list<string>}
 
-  <li id="{$prefix}{$id}" class="{$prefix}container js-project-step">
-    <div class="{$prefix}header js-project-step-header">
+  <li id="{$prefix}{$id}" class="{$prefix}container {$prefix}step">
+    <div class="{$prefix}header">
       <div class="{$prefix}number">
         <span class="{$prefix}number-text">{$number}</span>
         <span class="{$prefix}number-check">
@@ -98,13 +99,13 @@
       <div class="{$prefix}description">{$description}</div>
       <div class="{$prefix}media">
         {foreach $image in $images}
-          <button type="button" class="{$prefix}media-expand js-project-step-media-expand" title="Expand image" data-media-type="image">
-            <img data-src="{$image}" alt="" class="{$prefix}media-item js-project-step-image">
+          <button type="button" class="{$prefix}media-expand {$prefix}media-expand" title="Expand image" data-media-type="image">
+            <img data-src="{$image}" alt="" class="{$prefix}media-item {$prefix}image">
             <i class="material-icons">fullscreen</i>
           </button>
         {/foreach}
         {foreach $video in $videos}
-          <button type="button" class="{$prefix}media-expand {$prefix}media-expand js-project-step-media-expand" title="Expand video" data-media-type="video" data-video-url="{$video}">
+          <button type="button" class="{$prefix}media-expand {$prefix}media-expand {$prefix}media-expand" title="Expand video" data-media-type="video" data-video-url="{$video}">
             <div class="{$prefix}media-item-video">
               <i class="material-icons">play_circle_outline</i>
             </div>
@@ -112,7 +113,7 @@
         {/foreach}
         {if $online}
           {foreach $video in $youtube_videos}
-            <button type="button" class="{$prefix}media-expand {$prefix}media-expand js-project-step-media-expand" title="Expand video" data-media-type="youtube" data-youtube-id="{$video}">
+            <button type="button" class="{$prefix}media-expand {$prefix}media-expand {$prefix}media-expand" title="Expand video" data-media-type="youtube" data-youtube-id="{$video}">
               <div class="{$prefix}media-item-video">
                 <i class="material-icons">play_circle_outline</i>
               </div>
@@ -120,11 +121,16 @@
           {/foreach}
         {/if}
       </div>
-      {if not $isLastStep}
         <div class="{$prefix}actions">
-          <button type="button" class="mdl-button mdl-js-button mdl-button--colored mdl-button--raised js-project-step-continue">Continue</button>
+          {if $hasCode}
+            <button type="button" class="mdl-button mdl-js-button mdl-button--colored mdl-button--raised {$prefix}load-code">
+              <i class='material-icons'>chevron_left</i><label>Load Example Code</label>
+            </button>
+          {/if}
+          {if not $isLastStep}
+            <button type="button" class="mdl-button mdl-js-button mdl-button--colored mdl-button--raised {$prefix}continue">Continue</button>
+          {/if}
         </div>
-      {/if}
     </div>
   </li>
 {/template}


### PR DESCRIPTION
@MarkusBordihn 

The tutorial has a feature that can load code each time a step is selected. The SVG triangle example (Advanced\Programming\Javascript\SVG) demonstrates this feature.

That feature previously overwrite the user's changes to the editor when a new step was loaded. This PR fixes that by only loading code if the editor is empty or matches the previous step's code. It also provides a button for the user to load the code and warns users that it will overwrite their code.