### PR TITLE
Workbench add-on updates

### DIFF
--- a/src/addon/workbench/workbench_map.js
+++ b/src/addon/workbench/workbench_map.js
@@ -22,91 +22,113 @@ goog.provide('cwc.addon.WorkbenchMap');
 
 cwc.addon.WorkbenchMap = {
   'CWC Advanced - 3D': {
-    appendNode: '#select-screen-tab-graphic .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-advanced-graphic .mdl-grid',
     mode: cwc.mode.Type.BASIC,
+    wbTagId: 915,
   },
   'CWC Advanced - AIY': {
-    appendNode: '#select-screen-tab-aiy .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-advanced-aiy .mdl-grid',
     mode: cwc.mode.Type.AIY,
+    wbTagId: 916,
   },
   'CWC Advanced - CoffeeScript': {
-    appendNode: '#select-screen-tab-coffeescript .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-advanced-coffeescript .mdl-grid',
     mode: cwc.mode.Type.COFFEESCRIPT,
+    wbTagId: 917,
   },
   'CWC Advanced - EV3': {
-    appendNode: '#select-screen-tab-lego_ev3 .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-advanced-lego_ev3 .mdl-grid',
     mode: cwc.mode.Type.EV3,
+    wbTagId: 918,
   },
   'CWC Advanced - Games': {
-    appendNode: '#select-screen-tab-games .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-advanced-games .mdl-grid',
     mode: cwc.mode.Type.PHASER,
+    wbTagId: 919,
   },
   'CWC Advanced - HTML5': {
-    appendNode: '#select-screen-tab-html5 .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-advanced-html5 .mdl-grid',
     mode: cwc.mode.Type.HTML5,
+    wbTagId: 540,
   },
   'CWC Advanced - JavaScript': {
-    appendNode: '#select-screen-tab-javascript .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-advanced-javascript .mdl-grid',
     mode: cwc.mode.Type.JAVASCRIPT,
+    wbTagId: 920,
   },
   'CWC Advanced - Pencil Code': {
-    appendNode: '#select-screen-tab-pencil_code .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-advanced-pencil_code .mdl-grid',
     mode: cwc.mode.Type.PENCIL_CODE,
+    wbTagId: 921,
   },
   'CWC Advanced - Python 2.7': {
-    appendNode: '#select-screen-tab-python27 .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-advanced-python27 .mdl-grid',
     mode: cwc.mode.Type.PYTHON27,
+    wbTagId: 922,
   },
   'CWC Advanced - Python 3.x': {
-    appendNode: '#select-screen-tab-python .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-advanced-python .mdl-grid',
     mode: cwc.mode.Type.PYTHON,
+    wbTagId: 923,
   },
   'CWC Advanced - Simple': {
-    appendNode: '#select-screen-tab-basic .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-advanced-basic .mdl-grid',
     mode: cwc.mode.Type.BASIC,
+    wbTagId: 924,
   },
   'CWC Advanced - Sphero 2.0': {
-    appendNode: '#select-screen-tab-sphero_classic .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-advanced-sphero_classic .mdl-grid',
     mode: cwc.mode.Type.SPHERO,
+    wbTagId: 925,
   },
   'CWC Advanced - Sphero BB-8': {
-    appendNode: '#select-screen-tab-sphero_bb8 .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-advanced-sphero_bb8 .mdl-grid',
     mode: 'sphero_bb8', // TODO: this is missing
+    wbTagId: 926,
   },
   'CWC Advanced - Sphero SPRK+': {
-    appendNode: '#select-screen-tab-sphero_sprk_plus .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-advanced-sphero_sprk_plus .mdl-grid',
     mode: cwc.mode.Type.SPHERO_SPRK_PLUS,
+    wbTagId: 927,
   },
   'CWC Beginner - Blocks': {
-    appendNode: '#select-screen-tab-blocks .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-beginner-blocks .mdl-grid',
     mode: cwc.mode.Type.BASIC_BLOCKLY,
+    wbTagId: 928,
   },
   'CWC Beginner - EV3': {
-    appendNode: '#select-screen-tab-lego_ev3 .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-beginner-lego_ev3 .mdl-grid',
     mode: cwc.mode.Type.EV3_BLOCKLY,
+    wbTagId: 929,
   },
   'CWC Beginner - Games': {
-    appendNode: '#select-screen-tab-games .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-beginner-games .mdl-grid',
     mode: cwc.mode.Type.PHASER_BLOCKLY,
+    wbTagId: 930,
   },
   'CWC Beginner - Sphero 2.0': {
-    appendNode: '#select-screen-tab-sphero_classic .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-beginner-sphero_classic .mdl-grid',
     mode: cwc.mode.Type.SPHERO_BLOCKLY,
+    wbTagId: 931,
   },
   'CWC Beginner - Sphero BB-8': {
-    appendNode: '#select-screen-tab-sphero_bb8 .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-beginner-sphero_bb8 .mdl-grid',
     mode: cwc.mode.Type.SPHERO_BB8_BLOCKLY,
+    wbTagId: 932,
   },
   'CWC Beginner - Sphero SPRK+': {
-    appendNode: '#select-screen-tab-sphero_sprk_plus .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-beginner-sphero_sprk_plus .mdl-grid',
     mode: cwc.mode.Type.SPHERO_SPRK_PLUS_BLOCKLY,
+    wbTagId: 933,
   },
   'CWC Beginner - mBot Blue': {
-    appendNode: '#select-screen-tab-makeblock_mbot .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-beginner-makeblock_mbot .mdl-grid',
     mode: cwc.mode.Type.MBOT_BLOCKLY,
+    wbTagId: 934,
   },
   'CWC Beginner - mBot Ranger': {
-    appendNode: '#select-screen-tab-makeblock_mbot_ranger .cwc-tutorial-list',
+    appendNode: '#select-screen-tab-beginner-makeblock_mbot_ranger .mdl-grid',
     mode: cwc.mode.Type.MBOT_RANGER_BLOCKLY,
+    wbTagId: 935,
   },
 };

--- a/src/ui/select_screen/advanced/advanced.soy
+++ b/src/ui/select_screen/advanced/advanced.soy
@@ -34,49 +34,49 @@
 
         {call cwc.soy.SelectScreenTemplate.mainTabBarLink}
           {param active: true /}
-          {param id: 'overview' /}
+          {param id: 'advanced-overview' /}
           {param name: '@@GENERAL__OVERVIEW' /}
           {param icon: 'apps' /}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.mainTabBarLink}
-          {param id: 'basic' /}
+          {param id: 'advanced-basic' /}
           {param name: 'Basic' /}
           {param icon kind="html"}{call cwc.soy.SelectScreenAdvanced.basic.icon /}{/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.mainTabBarLink}
-          {param id: 'games' /}
+          {param id: 'advanced-games' /}
           {param name: 'Games' /}
           {param icon kind="html"}{call cwc.soy.SelectScreenAdvanced.games.icon /}{/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.mainTabBarLink}
-          {param id: 'programming' /}
+          {param id: 'advanced-programming' /}
           {param name: 'Programming' /}
           {param icon kind="html"}{call cwc.soy.SelectScreenAdvanced.programming.icon /}{/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.mainTabBarLink}
-          {param id: 'markup' /}
+          {param id: 'advanced-markup' /}
           {param name: 'Markup' /}
           {param icon kind="html"}{call cwc.soy.SelectScreenAdvanced.markup.icon /}{/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.mainTabBarLink}
-          {param id: 'robots' /}
+          {param id: 'advanced-robots' /}
           {param name: 'Robots' /}
           {param icon kind="html"}{call cwc.soy.SelectScreenAdvanced.robot.icon /}{/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.mainTabBarLink}
-          {param id: 'graphic' /}
+          {param id: 'advanced-graphic' /}
           {param name: 'Graphic' /}
           {param icon kind="html"}{call cwc.soy.SelectScreenAdvanced.graphic.icon /}{/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.mainTabBarLink}
-          {param id: 'aiy' /}
+          {param id: 'advanced-aiy' /}
           {param name: 'AIY' /}
           {param icon kind="html"}{call cwc.soy.SelectScreenAdvanced.aiy.icon /}{/param}
         {/call}
@@ -87,56 +87,56 @@
 
       {call cwc.soy.SelectScreenTemplate.mainTabBarContent}
         {param active: true /}
-        {param id: 'overview' /}
+        {param id: 'advanced-overview' /}
         {param content kind="html"}
           {call .overview data="all" /}
         {/param}
       {/call}
 
       {call cwc.soy.SelectScreenTemplate.mainTabBarContent}
-        {param id: 'basic' /}
+        {param id: 'advanced-basic' /}
         {param content kind="html"}
           {call cwc.soy.SelectScreenAdvanced.basic.overview data="all" /}
         {/param}
       {/call}
 
       {call cwc.soy.SelectScreenTemplate.mainTabBarContent}
-        {param id: 'games' /}
+        {param id: 'advanced-games' /}
         {param content kind="html"}
           {call cwc.soy.SelectScreenAdvanced.games.overview data="all" /}
         {/param}
       {/call}
 
       {call cwc.soy.SelectScreenTemplate.mainTabBarContent}
-        {param id: 'programming' /}
+        {param id: 'advanced-programming' /}
         {param content kind="html"}
           {call cwc.soy.SelectScreenAdvanced.programming.template data="all" /}
         {/param}
       {/call}
 
       {call cwc.soy.SelectScreenTemplate.mainTabBarContent}
-        {param id: 'markup' /}
+        {param id: 'advanced-markup' /}
         {param content kind="html"}
           {call cwc.soy.SelectScreenAdvanced.markup.template data="all" /}
         {/param}
       {/call}
 
       {call cwc.soy.SelectScreenTemplate.mainTabBarContent}
-        {param id: 'robots' /}
+        {param id: 'advanced-robots' /}
         {param content kind="html"}
           {call cwc.soy.SelectScreenAdvanced.robot.template data="all" /}
         {/param}
       {/call}
 
       {call cwc.soy.SelectScreenTemplate.mainTabBarContent}
-        {param id: 'graphic' /}
+        {param id: 'advanced-graphic' /}
         {param content kind="html"}
           {call cwc.soy.SelectScreenAdvanced.graphic.overview data="all" /}
         {/param}
       {/call}
 
       {call cwc.soy.SelectScreenTemplate.mainTabBarContent}
-        {param id: 'aiy' /}
+        {param id: 'advanced-aiy' /}
         {param content kind="html"}
           {call cwc.soy.SelectScreenAdvanced.aiy.overview data="all" /}
         {/param}
@@ -168,7 +168,7 @@
         {param title: 'Simple' /}
         {param text: 'JavaScript made easy through easy starter functions' /}
         {param link_text: 'Go Simple' /}
-        {param tab: 'basic' /}
+        {param tab: 'advanced-basic' /}
         {param opt_color_class: 'bg-light-blue' /}
         {param opt_icon: 'school' /}
       {/call}
@@ -177,7 +177,7 @@
         {param title: 'Games' /}
         {param text: 'Create games with the Phaser framework' /}
         {param link_text: 'Start creating games' /}
-        {param tab: 'games' /}
+        {param tab: 'advanced-games' /}
         {param opt_color_class: 'bg-lime' /}
         {param opt_icon: 'videogame_asset' /}
       {/call}
@@ -186,7 +186,7 @@
         {param title: 'Programming' /}
         {param text: 'Build software with text-based programming languages' /}
         {param link_text: 'Go Coding ' /}
-        {param tab: 'programming' /}
+        {param tab: 'advanced-programming' /}
         {param opt_color_class: 'bg-blue' /}
         {param opt_icon: 'view_stream' /}
       {/call}
@@ -195,7 +195,7 @@
         {param title: 'Markup' /}
         {param text: 'Put together the components of a website- HTML, CSS and JavaScript' /}
         {param link_text: 'Go Web' /}
-        {param tab: 'markup' /}
+        {param tab: 'advanced-markup' /}
         {param opt_color_class: 'bg-blue' /}
         {param opt_icon: 'public' /}
       {/call}
@@ -204,7 +204,7 @@
         {param title: 'Robots' /}
         {param text: 'Control real or virtual robots' /}
         {param link_text: 'Go Robots' /}
-        {param tab: 'robots' /}
+        {param tab: 'advanced-robots' /}
         {param opt_color_class: 'bg-orange' /}
         {param opt_icon: 'memory' /}
       {/call}
@@ -213,7 +213,7 @@
         {param title: '3D' /}
         {param text: 'Create and display animated 3D computer graphics' /}
         {param link_text: 'Start drawing' /}
-        {param tab: 'graphic' /}
+        {param tab: 'advanced-graphic' /}
         {param opt_color_class: 'bg-blue' /}
         {param opt_icon: '3d_rotation' /}
       {/call}
@@ -222,7 +222,7 @@
         {param title: 'AIY' /}
         {param text: 'Build for one of the Google AIY kits' /}
         {param link_text: 'Start with AIY' /}
-        {param tab: 'aiy' /}
+        {param tab: 'advanced-aiy' /}
         {param opt_color_class: 'bg-orange' /}
         {param opt_icon: 'build' /}
       {/call}

--- a/src/ui/select_screen/advanced/markup/markup.soy
+++ b/src/ui/select_screen/advanced/markup/markup.soy
@@ -39,12 +39,12 @@
 
         {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
           {param active: true /}
-          {param id: 'markup_overview' /}
+          {param id: 'advanced-markup_overview' /}
           {param name: '@@GENERAL__OVERVIEW' /}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
-          {param id: 'html5' /}
+          {param id: 'advanced-html5' /}
           {param name: 'HTML5' /}
         {/call}
 
@@ -54,14 +54,14 @@
 
         {call cwc.soy.SelectScreenTemplate.subTabBarContent}
           {param active: true /}
-          {param id: 'markup_overview' /}
+          {param id: 'advanced-markup_overview' /}
           {param content kind="html"}
             {call .overview data="all" /}
           {/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarContent}
-          {param id: 'html5' /}
+          {param id: 'advanced-html5' /}
           {param content kind="html"}
             {call cwc.soy.SelectScreenAdvanced.markup.html5.overview data="all" /}
           {/param}
@@ -91,7 +91,7 @@
 
     {param content kind="html"}
       {call cwc.soy.SelectScreenTemplate.selectSection data="all"}
-        {param id: 'html5' /}  
+        {param id: 'advanced-html5' /}
         {param title: 'HTML5' /}
         {param text: 'Create applications and websites using HTML, CSS and JavaScript' /}
         {param opt_color_class: 'bg-orange' /}
@@ -100,7 +100,7 @@
         {param content kind="html"}
           {call cwc.soy.SelectScreenTemplate.selectSectionLink}
             {param text: 'HTML5' /}
-            {param tab: 'html5' /}
+            {param tab: 'advanced-html5' /}
           {/call}
         {/param}
       {/call}

--- a/src/ui/select_screen/advanced/programming/programming.soy
+++ b/src/ui/select_screen/advanced/programming/programming.soy
@@ -39,32 +39,32 @@
 
         {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
           {param active: true /}
-          {param id: 'programming_overview' /}
+          {param id: 'advanced-programming_overview' /}
           {param name: '@@GENERAL__OVERVIEW' /}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
-          {param id: 'javascript' /}
+          {param id: 'advanced-javascript' /}
           {param name: 'JavaScript' /}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
-          {param id: 'python' /}
+          {param id: 'advanced-python' /}
           {param name: 'Python' /}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
-          {param id: 'python27' /}
+          {param id: 'advanced-python27' /}
           {param name: 'Python 2.7' /}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
-          {param id: 'coffeescript' /}
+          {param id: 'advanced-coffeescript' /}
           {param name: 'Coffeescript' /}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
-          {param id: 'pencil_code' /}
+          {param id: 'advanced-pencil_code' /}
           {param name: 'Pencil Code' /}
         {/call}
 
@@ -74,42 +74,42 @@
 
         {call cwc.soy.SelectScreenTemplate.subTabBarContent}
           {param active: true /}
-          {param id: 'programming_overview' /}
+          {param id: 'advanced-programming_overview' /}
           {param content kind="html"}
             {call .overview data="all" /}
           {/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarContent}
-          {param id: 'javascript' /}
+          {param id: 'advanced-javascript' /}
           {param content kind="html"}
             {call cwc.soy.SelectScreenAdvanced.programming.javascript.overview data="all" /}
           {/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarContent}
-          {param id: 'python' /}
+          {param id: 'advanced-python' /}
           {param content kind="html"}
             {call cwc.soy.SelectScreenAdvanced.programming.python.overview data="all" /}
           {/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarContent}
-          {param id: 'python27' /}
+          {param id: 'advanced-python27' /}
           {param content kind="html"}
             {call cwc.soy.SelectScreenAdvanced.programming.python27.overview data="all" /}
           {/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarContent}
-          {param id: 'coffeescript' /}
+          {param id: 'advanced-coffeescript' /}
           {param content kind="html"}
             {call cwc.soy.SelectScreenAdvanced.programming.coffeescript.overview data="all" /}
           {/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarContent}
-          {param id: 'pencil_code' /}
+          {param id: 'advanced-pencil_code' /}
           {param content kind="html"}
             {call cwc.soy.SelectScreenAdvanced.programming.pencil_code.overview data="all" /}
           {/param}
@@ -139,7 +139,7 @@
 
     {param content kind="html"}
       {call cwc.soy.SelectScreenTemplate.selectSection data="all"}
-        {param id: 'javascript' /}
+        {param id: 'advanced-javascript' /}
         {param title: 'JavaScript' /}
         {param text: 'Use JavaScript to create programs' /}
         {param opt_color_class: 'bg-orange' /}
@@ -148,13 +148,13 @@
         {param content kind="html"}
           {call cwc.soy.SelectScreenTemplate.selectSectionLink}
             {param text: 'JavaScript' /}
-            {param tab: 'javascript' /}
+            {param tab: 'advanced-javascript' /}
           {/call}
         {/param}
       {/call}
 
       {call cwc.soy.SelectScreenTemplate.selectSection data="all"}
-        {param id: 'python' /}
+        {param id: 'advanced-python' /}
         {param title: 'Python' /}
         {param text: 'Use the Python language to create programs' /}
         {param opt_color_class: 'bg-orange' /}
@@ -163,18 +163,18 @@
         {param content kind="html"}
           {call cwc.soy.SelectScreenTemplate.selectSectionLink}
             {param text: 'Python' /}
-            {param tab: 'python' /}
+            {param tab: 'advanced-python' /}
           {/call}
 
           {call cwc.soy.SelectScreenTemplate.selectSectionLink}
             {param text: 'Python 2.7' /}
-            {param tab: 'python27' /}
+            {param tab: 'advanced-python27' /}
           {/call}
         {/param}
       {/call}
 
       {call cwc.soy.SelectScreenTemplate.selectSection data="all"}
-        {param id: 'coffeescript' /}
+        {param id: 'advanced-coffeescript' /}
         {param title: 'CoffeeScript' /}
         {param text: 'Use the simple CoffeeScript language to create programs' /}
         {param opt_color_class: 'bg-orange' /}
@@ -183,13 +183,13 @@
         {param content kind="html"}
           {call cwc.soy.SelectScreenTemplate.selectSectionLink}
             {param text: 'CoffeeScript' /}
-            {param tab: 'coffeescript' /}
+            {param tab: 'advanced-coffeescript' /}
           {/call}
         {/param}
       {/call}
 
       {call cwc.soy.SelectScreenTemplate.selectSection data="all"}
-        {param id: 'pencil_code' /}
+        {param id: 'advanced-pencil_code' /}
         {param title: 'Pencil Code' /}
         {param text: 'Draw art, play music or create games' /}
         {param opt_color_class: 'bg-orange' /}
@@ -198,7 +198,7 @@
         {param content kind="html"}
           {call cwc.soy.SelectScreenTemplate.selectSectionLink}
             {param text: 'Pencil Code' /}
-            {param tab: 'pencil_code' /}
+            {param tab: 'advanced-pencil_code' /}
           {/call}
         {/param}
       {/call}

--- a/src/ui/select_screen/advanced/robot/robot.soy
+++ b/src/ui/select_screen/advanced/robot/robot.soy
@@ -40,31 +40,31 @@
 
         {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
           {param active: true /}
-          {param id: 'robot_overview' /}
+          {param id: 'advanced-robot_overview' /}
           {param name: '@@GENERAL__OVERVIEW' /}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
-          {param id: 'lego_ev3' /}
+          {param id: 'advanced-lego_ev3' /}
           {param module: 'lego' /}
           {param name: 'EV3' /}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
-          {param id: 'sphero_classic' /}
+          {param id: 'advanced-sphero_classic' /}
           {param module: 'sphero' /}
           {param name: 'Sphero 2.0' /}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
-          {param id: 'sphero_sprk_plus' /}
+          {param id: 'advanced-sphero_sprk_plus' /}
           {param module: 'sphero' /}
           {param name: 'Sphero SPRK+' /}
         {/call}
 
         {if $experimental}
           {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
-            {param id: 'sphero_bb8' /}
+            {param id: 'advanced-sphero_bb8' /}
             {param module: 'sphero' /}
             {param name: 'Sphero BB-8' /}
           {/call}
@@ -76,28 +76,28 @@
 
         {call cwc.soy.SelectScreenTemplate.subTabBarContent}
           {param active: true /}
-          {param id: 'robot_overview' /}
+          {param id: 'advanced-robot_overview' /}
           {param content kind="html"}
             {call .overview data="all" /}
           {/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarContent}
-          {param id: 'lego_ev3' /}
+          {param id: 'advanced-lego_ev3' /}
           {param content kind="html"}
             {call cwc.soy.SelectScreenAdvanced.robot.lego.ev3.overview data="all" /}
           {/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarContent}
-          {param id: 'sphero_classic' /}
+          {param id: 'advanced-sphero_classic' /}
           {param content kind="html"}
             {call cwc.soy.SelectScreenAdvanced.robot.sphero.classic.overview data="all" /}
           {/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarContent}
-          {param id: 'sphero_sprk_plus' /}
+          {param id: 'advanced-sphero_sprk_plus' /}
           {param content kind="html"}
             {call cwc.soy.SelectScreenAdvanced.robot.sphero.sprkPlus.overview data="all" /}
           {/param}
@@ -105,7 +105,7 @@
 
         {if $experimental}
           {call cwc.soy.SelectScreenTemplate.subTabBarContent}
-            {param id: 'sphero_bb8' /}
+            {param id: 'advanced-sphero_bb8' /}
             {param content kind="html"}
               {call cwc.soy.SelectScreenAdvanced.robot.sphero.bb8.overview data="all" /}
             {/param}
@@ -139,7 +139,7 @@
 
       {call cwc.soy.SelectScreenTemplate.selectSection data="all"}
         {param title: 'Lego' /}
-        {param id: 'lego' /}
+        {param id: 'advanced-lego' /}
         {param text: 'Control a real or virtual EV3' /}
         {param opt_color_class: 'bg-orange' /}
         {param opt_icon: 'adb' /}
@@ -147,7 +147,7 @@
         {param content kind="html"}
           {call cwc.soy.SelectScreenTemplate.selectSectionLink}
             {param text: 'EV3 Robot' /}
-            {param tab: 'lego_ev3' /}
+            {param tab: 'advanced-lego_ev3' /}
           {/call}
         {/param}
 
@@ -155,7 +155,7 @@
 
       {call cwc.soy.SelectScreenTemplate.selectSection data="all"}
         {param title: 'Sphero' /}
-        {param id: 'sphero' /}
+        {param id: 'advanced-sphero' /}
         {param text: 'Control a real or virtual Sphero' /}
         {param opt_color_class: 'bg-orange' /}
         {param opt_icon: 'adjust' /}
@@ -163,18 +163,18 @@
         {param content kind="html"}
           {call cwc.soy.SelectScreenTemplate.selectSectionLink}
             {param text: 'Sphero 2.0 robot' /}
-            {param tab: 'sphero_classic' /}
+            {param tab: 'advanced-sphero_classic' /}
           {/call}
 
           {call cwc.soy.SelectScreenTemplate.selectSectionLink}
             {param text: 'Sphero SPRK+ robot' /}
-            {param tab: 'sphero_sprk_plus' /}
+            {param tab: 'advanced-sphero_sprk_plus' /}
           {/call}
 
           {if $experimental}
             {call cwc.soy.SelectScreenTemplate.selectSectionLink}
               {param text: 'Sphero BB-8 robot' /}
-              {param tab: 'sphero_bb8' /}
+              {param tab: 'advanced-sphero_bb8' /}
             {/call}
           {/if}
         {/param}

--- a/src/ui/select_screen/normal/normal.soy
+++ b/src/ui/select_screen/normal/normal.soy
@@ -34,25 +34,25 @@
 
         {call cwc.soy.SelectScreenTemplate.mainTabBarLink data="all"}
           {param active: true /}
-          {param id: 'overview' /}
+          {param id: 'beginner-overview' /}
           {param name: '@@GENERAL__OVERVIEW' /}
           {param icon: 'apps' /}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.mainTabBarLink data="all"}
-          {param id: 'blocks' /}
+          {param id: 'beginner-blocks' /}
           {param name: 'Blocks' /}
           {param icon kind="html"}{call cwc.soy.SelectScreenNormal.basic.icon /}{/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.mainTabBarLink data="all"}
-          {param id: 'games' /}
+          {param id: 'beginner-games' /}
           {param name: 'Games' /}
           {param icon kind="html"}{call cwc.soy.SelectScreenNormal.games.icon /}{/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.mainTabBarLink data="all"}
-          {param id: 'robots' /}
+          {param id: 'beginner-robots' /}
           {param name: 'Robots' /}
           {param icon kind="html"}{call cwc.soy.SelectScreenNormal.robot.icon /}{/param}
         {/call}
@@ -63,28 +63,28 @@
 
       {call cwc.soy.SelectScreenTemplate.mainTabBarContent}
         {param active: true /}
-        {param id: 'overview' /}
+        {param id: 'beginner-overview' /}
         {param content kind="html"}
           {call .overview data="all" /}
         {/param}
       {/call}
 
       {call cwc.soy.SelectScreenTemplate.mainTabBarContent}
-        {param id: 'blocks' /}
+        {param id: 'beginner-blocks' /}
         {param content kind="html"}
           {call cwc.soy.SelectScreenNormal.basic.overview data="all" /}
         {/param}
       {/call}
 
       {call cwc.soy.SelectScreenTemplate.mainTabBarContent}
-        {param id: 'games' /}
+        {param id: 'beginner-games' /}
         {param content kind="html"}
           {call cwc.soy.SelectScreenNormal.games.overview data="all" /}
         {/param}
       {/call}
 
       {call cwc.soy.SelectScreenTemplate.mainTabBarContent}
-        {param id: 'robots' /}
+        {param id: 'beginner-robots' /}
         {param content kind="html"}
           {call cwc.soy.SelectScreenNormal.robot.template data="all" /}
         {/param}
@@ -113,7 +113,7 @@
     {param content kind="html"}
 
       {call cwc.soy.SelectScreenTemplate.selectCard data="all"}
-        {param tab: 'blocks' /}
+        {param tab: 'beginner-blocks' /}
         {param link_text: '@@SELECT_SCREEN_NORMAL__BLOCKLY_ACTION' /}
         {param text: '@@SELECT_SCREEN_NORMAL__BLOCKLY_TEXT' /}
         {param title: '@@SELECT_SCREEN_NORMAL__BLOCKLY' /}
@@ -122,7 +122,7 @@
       {/call}
 
       {call cwc.soy.SelectScreenTemplate.selectCard data="all"}
-        {param tab: 'games' /}
+        {param tab: 'beginner-games' /}
         {param link_text: '@@SELECT_SCREEN_NORMAL__GAME_ACTION' /}
         {param text: '@@SELECT_SCREEN_NORMAL__GAME_TEXT' /}
         {param title: '@@SELECT_SCREEN_NORMAL__GAME' /}
@@ -131,7 +131,7 @@
       {/call}
 
       {call cwc.soy.SelectScreenTemplate.selectCard data="all"}
-        {param tab: 'robots' /}
+        {param tab: 'beginner-robots' /}
         {param link_text: '@@SELECT_SCREEN_NORMAL__ROBOTS_ACTION' /}
         {param text: '@@SELECT_SCREEN_NORMAL__ROBOTS_TEXT' /}
         {param title: '@@SELECT_SCREEN_NORMAL__ROBOTS' /}

--- a/src/ui/select_screen/normal/robot/robot.soy
+++ b/src/ui/select_screen/normal/robot/robot.soy
@@ -40,51 +40,51 @@
 
         {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
           {param active: true /}
-          {param id: 'robot_overview' /}
+          {param id: 'beginner-robot_overview' /}
           {param name: '@@GENERAL__OVERVIEW' /}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
-          {param id: 'lego_ev3' /}
+          {param id: 'beginner-lego_ev3' /}
           {param module: 'lego' /}
           {param name: 'EV3' /}
         {/call}
 
         {if $experimental}
           {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
-            {param id: 'lego_wedo2' /}
+            {param id: 'beginner-lego_wedo2' /}
             {param module: 'lego' /}
             {param name: 'WeDo 2.0' /}
           {/call}
         {/if}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
-          {param id: 'makeblock_mbot' /}
+          {param id: 'beginner-makeblock_mbot' /}
           {param module: 'makeblock' /}
           {param name: 'mBot' /}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
-          {param id: 'makeblock_mbot_ranger' /}
+          {param id: 'beginner-makeblock_mbot_ranger' /}
           {param module: 'makeblock' /}
           {param name: 'mBot Ranger' /}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
-          {param id: 'sphero_classic' /}
+          {param id: 'beginner-sphero_classic' /}
           {param module: 'sphero' /}
           {param name: 'Sphero 2.0' /}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
-          {param id: 'sphero_sprk_plus' /}
+          {param id: 'beginner-sphero_sprk_plus' /}
           {param module: 'sphero' /}
           {param name: 'Sphero SPRK+' /}
         {/call}
 
         {if $experimental}
           {call cwc.soy.SelectScreenTemplate.subTabBarLink data="all"}
-            {param id: 'sphero_bb8' /}
+            {param id: 'beginner-sphero_bb8' /}
             {param module: 'sphero' /}
             {param name: 'Sphero BB-8' /}
           {/call}
@@ -96,14 +96,14 @@
 
         {call cwc.soy.SelectScreenTemplate.subTabBarContent}
           {param active: true /}
-          {param id: 'robot_overview' /}
+          {param id: 'beginner-robot_overview' /}
           {param content kind="html"}
             {call .overview data="all" /}
           {/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarContent}
-          {param id: 'lego_ev3' /}
+          {param id: 'beginner-lego_ev3' /}
           {param content kind="html"}
             {call cwc.soy.SelectScreenNormal.robot.lego.ev3.overview data="all" /}
           {/param}
@@ -111,7 +111,7 @@
 
         {if $experimental}
           {call cwc.soy.SelectScreenTemplate.subTabBarContent}
-            {param id: 'lego_wedo2' /}
+            {param id: 'beginner-lego_wedo2' /}
             {param content kind="html"}
               {call cwc.soy.SelectScreenNormal.robot.lego.weDo2.overview data="all" /}
             {/param}
@@ -119,28 +119,28 @@
         {/if}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarContent}
-          {param id: 'makeblock_mbot' /}
+          {param id: 'beginner-makeblock_mbot' /}
           {param content kind="html"}
             {call cwc.soy.SelectScreenNormal.robot.makeblock.mBot.overview data="all" /}
           {/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarContent}
-          {param id: 'makeblock_mbot_ranger' /}
+          {param id: 'beginner-makeblock_mbot_ranger' /}
           {param content kind="html"}
             {call cwc.soy.SelectScreenNormal.robot.makeblock.mBotRanger.overview data="all" /}
           {/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarContent}
-          {param id: 'sphero_classic' /}
+          {param id: 'beginner-sphero_classic' /}
           {param content kind="html"}
             {call cwc.soy.SelectScreenNormal.robot.sphero.classic.overview data="all" /}
           {/param}
         {/call}
 
         {call cwc.soy.SelectScreenTemplate.subTabBarContent}
-          {param id: 'sphero_sprk_plus' /}
+          {param id: 'beginner-sphero_sprk_plus' /}
           {param content kind="html"}
             {call cwc.soy.SelectScreenNormal.robot.sphero.sprkPlus.overview data="all" /}
           {/param}
@@ -148,7 +148,7 @@
 
         {if $experimental}
           {call cwc.soy.SelectScreenTemplate.subTabBarContent}
-            {param id: 'sphero_bb8' /}
+            {param id: 'beginner-sphero_bb8' /}
             {param content kind="html"}
               {call cwc.soy.SelectScreenNormal.robot.sphero.bb8.overview data="all" /}
             {/param}
@@ -182,7 +182,7 @@
 
       {call cwc.soy.SelectScreenTemplate.selectSection data="all"}
         {param title: 'Lego' /}
-        {param id: 'lego' /}
+        {param id: 'beginner-lego' /}
         {param text: 'Control a real or virtual EV3 by assembling Blockly Blocks' /}
         {param opt_color_class: 'bg-orange' /}
         {param opt_icon: 'adb' /}
@@ -190,13 +190,13 @@
         {param content kind="html"}
           {call cwc.soy.SelectScreenTemplate.selectSectionLink}
             {param text: 'EV3 Robot' /}
-            {param tab: 'lego_ev3' /}
+            {param tab: 'beginner-lego_ev3' /}
           {/call}
 
           {if $experimental}
             {call cwc.soy.SelectScreenTemplate.selectSectionLink}
               {param text: 'WeDo 2.0 robot' /}
-              {param tab: 'lego_wedo2' /}
+              {param tab: 'beginner-lego_wedo2' /}
             {/call}
           {/if}
         {/param}
@@ -204,7 +204,7 @@
 
       {call cwc.soy.SelectScreenTemplate.selectSection data="all"}
         {param title: 'Sphero' /}
-        {param id: 'sphero' /}
+        {param id: 'beginner-sphero' /}
         {param text: 'Control a real or virtual Sphero by assembling Blockly Blocks' /}
         {param opt_color_class: 'bg-orange' /}
         {param opt_icon: 'adjust' /}
@@ -212,18 +212,18 @@
         {param content kind="html"}
           {call cwc.soy.SelectScreenTemplate.selectSectionLink}
             {param text: 'Sphero 2.0 robot' /}
-            {param tab: 'sphero_classic' /}
+            {param tab: 'beginner-sphero_classic' /}
           {/call}
 
           {call cwc.soy.SelectScreenTemplate.selectSectionLink}
             {param text: 'Sphero SPRK+ robot' /}
-            {param tab: 'sphero_sprk_plus' /}
+            {param tab: 'beginner-sphero_sprk_plus' /}
           {/call}
 
           {if $experimental}
             {call cwc.soy.SelectScreenTemplate.selectSectionLink}
               {param text: 'Sphero BB-8 robot' /}
-              {param tab: 'sphero_bb8' /}
+              {param tab: 'beginner-sphero_bb8' /}
             {/call}
           {/if}
         {/param}
@@ -231,7 +231,7 @@
 
       {call cwc.soy.SelectScreenTemplate.selectSection data="all"}
         {param title: 'MakeBlock' /}
-        {param id: 'makeblock' /}
+        {param id: 'beginner-makeblock' /}
         {param text: 'Control an mBot by assembling Blockly Blocks' /}
         {param opt_color_class: 'bg-orange' /}
         {param opt_icon: 'functions' /}
@@ -240,12 +240,12 @@
         {param content kind="html"}
           {call cwc.soy.SelectScreenTemplate.selectSectionLink}
             {param text: 'mBot - Blue Robot' /}
-            {param tab: 'makeblock_mbot' /}
+            {param tab: 'beginner-makeblock_mbot' /}
           {/call}
 
           {call cwc.soy.SelectScreenTemplate.selectSectionLink}
             {param text: 'mBot Ranger Robot' /}
-            {param tab: 'makeblock_mbot_ranger' /}
+            {param tab: 'beginner-makeblock_mbot_ranger' /}
           {/call}
         {/param}
       {/call}


### PR DESCRIPTION
This PR gets the Workbench add-on in a fully functional state with the production Workbench site. The Workbench site now supports a publishing flow that allows creating lessons tagged with the necessary tags to pull it into any tag in Coding with Chrome.

Changes include:

- Give all CwC sections/tabs unique IDs so the Workbench add-on can correctly append lessons into the correct areas. Previously, some duplicate IDs prevented the Workbench add-on from correctly identifying each section.
- Updates to the Workbench v2 lessons API
- Links all the CwC modes to a tag in Workbench so lessons can be pulled into the right tab.
- Implements the solution discussed in https://github.com/google/coding-with-chrome/pull/164#issuecomment-392936783 to add a section and title dedicated to Workbench lessons for each tab. 
- Fixes a bug w/calling `startTutorial` when not necessary
- The add-on now prunes deleted WB lessons from the CwC database
- The add-on now accounts for paginated results from the WB API
- fixes bug w/`fireLoadCompleteListeners_` callback never being called (needed to re-render lessons after all data fetching completes).