### PR TITLE
Fixed bug with tutorial loading cached media

### DIFF
--- a/src/ui/tutorial/tutorial.js
+++ b/src/ui/tutorial/tutorial.js
@@ -176,7 +176,7 @@ cwc.ui.Tutorial.prototype.newTutorial = async function(language) {
   await this.setTutorial({
     'description': {
       'mime_type': 'text/plain',
-      'text': '<a href="#">this</a>is this a link',
+      'text': '',
     },
     'steps': [
       {
@@ -240,7 +240,8 @@ cwc.ui.Tutorial.prototype.addStep_ = async function(stepTemplate, id) {
     }
   }
 
-  await this.utils_.cacheMediaSet(stepTemplate['images'] || []);
+  stepTemplate['images'] = await this.utils_.cacheMediaSet(
+    stepTemplate['images'] || []);
 
   let tour = false;
   if (stepTemplate['tour']) {
@@ -302,7 +303,8 @@ cwc.ui.Tutorial.prototype.startTutorial = function() {
           youtube_videos: (step.videos || []).map((video) =>
             video['youtube_id']
           ),
-          hasCode: step.code && !goog.string.isEmptyOrWhitespace(step.code),
+          hasCode: (step.code && !goog.string.isEmptyOrWhitespace(step.code)) ?
+            true : false,
           hasTour: step.tour ? true : false,
         })),
       }

--- a/src/ui/tutorial/utils.js
+++ b/src/ui/tutorial/utils.js
@@ -92,22 +92,31 @@ cwc.ui.TutorialUtils.prototype.initImagesDb = async function(imagesDb) {
 /**
  * Caches a set of binary specs. Adds a database key to any successfully cached
  * specs.
- * @param {Object} specs
+ * @param {Array<Object>} specs
+ * @return {Array<Object>}
  */
 cwc.ui.TutorialUtils.prototype.cacheMediaSet = async function(specs) {
-  await Promise.all(specs.map(async (spec) => {
-    await this.cacheMedia(spec);
+  return await Promise.all(specs.map(async (spec) => {
+    return await this.cacheMedia(spec);
   }));
 };
 
 /**
  * Adds binary spec (json object with either a url or mime type and base64
  * encoded blob) to the cache and adds the database key to the object.
- * @param {Object} spec
+ * @param {Object|string} spec
+ * @return {Object}
  */
 cwc.ui.TutorialUtils.prototype.cacheMedia = async function(spec) {
-  await this.initImagesDb();
+  if (typeof spec == 'string') {
+    let specObj = {
+      'url': spec,
+    };
+    specObj[cwc.ui.TutorialUtils.databaseReferenceKey] = spec;
+    return specObj;
+  }
   let db_key = false;
+  await this.initImagesDb();
   if ('youtube_id' in spec) {
     let youtubeId = await this.getYouTubeVideoId(spec['youtube_id']);
     if (!youtubeId) {
@@ -124,6 +133,7 @@ cwc.ui.TutorialUtils.prototype.cacheMedia = async function(spec) {
   if (db_key) {
     spec[cwc.ui.TutorialUtils.databaseReferenceKey] = db_key;
   }
+  return spec;
 };
 
 /**

--- a/test/deps.js
+++ b/test/deps.js
@@ -235,7 +235,7 @@ goog.addDependency('../../../../src/ui/tutorial/editor/editor.js', ['cwc.ui.tuto
 goog.addDependency('../../../../src/ui/tutorial/editor/events.js', ['cwc.ui.tutorial.EditorEvents'], [], {});
 goog.addDependency('../../../../src/ui/tutorial/tutorial.js', ['cwc.ui.Tutorial'], ['cwc.mode.Type', 'cwc.soy.ui.Tutorial', 'cwc.ui.TutorialUtils', 'cwc.ui.TutorialValidator', 'cwc.ui.tutorial.Editor', 'cwc.ui.tutorial.EditorEvents', 'cwc.utils.Database', 'cwc.utils.Events', 'cwc.utils.Helper', 'cwc.utils.Logger', 'cwc.utils.Resources', 'cwc.utils.mime.Type', 'goog.dom', 'goog.dom.classes', 'goog.events', 'goog.html.SafeHtml', 'goog.soy', 'goog.string', 'goog.style', 'goog.ui.Component', 'soydata.VERY_UNSAFE'], {});
 goog.addDependency('../../../../src/ui/tutorial/utils.js', ['cwc.ui.TutorialUtils'], ['cwc.utils.Database', 'cwc.utils.Helper', 'cwc.utils.Logger', 'goog.html.sanitizer.HtmlSanitizer'], {});
-goog.addDependency('../../../../src/ui/tutorial/validator.js', ['cwc.ui.TutorialValidator'], ['cwc.soy.ui.Tutorial', 'cwc.utils.Events', 'cwc.utils.Helper', 'cwc.utils.Logger', 'goog.dom', 'goog.events'], {});
+goog.addDependency('../../../../src/ui/tutorial/validator.js', ['cwc.ui.TutorialValidator'], ['cwc.soy.ui.Tutorial', 'cwc.utils.Events', 'cwc.utils.Helper', 'cwc.utils.Logger', 'goog.dom', 'goog.events', 'goog.string'], {});
 goog.addDependency('../../../../src/ui/whats_new/whats_new.js', ['cwc.ui.WhatsNew'], ['cwc.soy.ui.WhatsNew', 'cwc.utils.Events', 'cwc.utils.Helper', 'goog.dom'], {});
 goog.addDependency('../../../../src/utils/byte_array.js', ['cwc.utils.ByteArray', 'cwc.utils.ByteArrayTypes'], [], {});
 goog.addDependency('../../../../src/utils/byte_tools.js', ['cwc.utils.ByteTools'], [], {});


### PR DESCRIPTION
The tutorial editor failed to properly load already cached media
from workbench. This fix allows it to do so correctly.