### PR TITLE
Fixes for unit tests

### DIFF
--- a/src/cache/cache.js
+++ b/src/cache/cache.js
@@ -131,7 +131,7 @@ cwc.Cache.prototype.addFile = function(name, content = '') {
   if (!content) {
     this.log_.warn('Received empty content for', name);
   }
-  return this.database_.add(name, content);
+  return this.database_.put(name, content);
 };
 
 

--- a/src/utils/resources.js
+++ b/src/utils/resources.js
@@ -23,12 +23,30 @@ goog.require('goog.net.XhrIo');
 
 
 /**
+ * Async unit tests that download files from github sometimes fail with
+ * a message that Jasmine's timeout was exceeded before done() was called.
+ * The root cause is that the request simply didn't complete quickly enough,
+ * but the error message doesn't indicate that. This function sets the timeout
+ * on network requests used in this module so that they timeout before
+ * Jasmine's timeout is exceeded causing unit tests to display useful error
+ * messages.
+ *
+ * @param {number} timeout
+ * @return {!goog.net.XhrIo}
+ */
+cwc.utils.Resources.getXhrIo = function(timeout = 10000) { // 10 seconds
+    let xhr = new goog.net.XhrIo();
+    xhr.setTimeoutInterval(timeout);
+    return xhr;
+};
+
+/**
  * @param {string} uri
  * @return {Promise}
  */
 cwc.utils.Resources.getUriAsText = function(uri) {
   return new Promise((resolve, reject) => {
-    let xhr = new goog.net.XhrIo();
+    let xhr = cwc.utils.Resources.getXhrIo();
     goog.events.listen(xhr, goog.net.EventType.SUCCESS, function(e) {
       let xhrResponse = /** @type {!goog.net.XhrIo} */ (e.target);
     resolve(xhrResponse.getResponseText() || '');
@@ -45,7 +63,7 @@ cwc.utils.Resources.getUriAsText = function(uri) {
  */
 cwc.utils.Resources.getUriAsBlob = function(uri) {
   return new Promise((resolve, reject) => {
-    let xhr = new goog.net.XhrIo();
+    let xhr = cwc.utils.Resources.getXhrIo();
     xhr.setResponseType(goog.net.XhrIo.ResponseType.BLOB);
     goog.events.listen(xhr, goog.net.EventType.SUCCESS, function(e) {
       let xhrResponse = /** @type {!goog.net.XhrIo} */ (e.target);
@@ -63,7 +81,7 @@ cwc.utils.Resources.getUriAsBlob = function(uri) {
  */
 cwc.utils.Resources.getUriAsBase64 = function(uri) {
   return new Promise((resolve, reject) => {
-    let xhr = new goog.net.XhrIo();
+    let xhr = cwc.utils.Resources.getXhrIo();
     xhr.setResponseType(goog.net.XhrIo.ResponseType.BLOB);
     goog.events.listen(xhr, goog.net.EventType.SUCCESS, function(e) {
       let xhrResponse = /** @type {!goog.net.XhrIo} */ (e.target);
@@ -111,7 +129,7 @@ cwc.utils.Resources.getUriAsJavaScriptTag = function(uri, nodeId) {
  */
 cwc.utils.Resources.getUriAsJson = function(uri) {
   return new Promise((resolve, reject) => {
-    let xhr = new goog.net.XhrIo();
+    let xhr = cwc.utils.Resources.getXhrIo();
     goog.events.listen(xhr, goog.net.EventType.SUCCESS, function(e) {
       let xhrResponse = /** @type {!goog.net.XhrIo} */ (e.target);
       resolve(xhrResponse.getResponseJson() || {});

--- a/test/unit_tests/utils/resources_test.js
+++ b/test/unit_tests/utils/resources_test.js
@@ -24,11 +24,33 @@ describe('Resources', function() {
   let urlPrefix = 'https://raw.githubusercontent.com/' +
     'google/coding-with-chrome/master/';
 
+  /*
+   * Because these functions download from the network, they can fail due to
+   * slow requests. This extends the Jasmine timeout to reduce the frequency
+   * of such failures. Note that this timeout should be longer than the XhrIo
+   * timeout set in cwc/utils/resources.js to ensure failure messages from unit
+   * tests distinguish between timeouts due to network failures from other
+   * failures directly related to our code.
+   */
+  let origTimeout;
+  beforeEach(() => {
+    // eslint-disable-next-line no-undef
+    origTimeout = jasmine.DEFAULT_TIMEOUT_INTERVAL;
+    // eslint-disable-next-line no-undef
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = 11000;
+  });
+  afterEach(() => {
+    // eslint-disable-next-line no-undef
+    jasmine.DEFAULT_TIMEOUT_INTERVAL = origTimeout;
+  });
+
   it('getUriAsText', function(done) {
     let url = urlPrefix + 'README.md';
      cwc.utils.Resources.getUriAsText(url).then((content) => {
       expect(content.includes('Coding with Chrome')).toEqual(true);
       done();
+    }).catch((exception) => {
+      done.fail(exception);
     });
   });
 
@@ -41,6 +63,8 @@ describe('Resources', function() {
         done();
       };
       reader.readAsText(blob);
+    }).catch((exception) => {
+      done.fail(exception);
     });
   });
 
@@ -49,6 +73,8 @@ describe('Resources', function() {
     cwc.utils.Resources.getUriAsBase64(url).then((content) => {
       expect(content.includes('Q29kaW5nIHdpdGggQ2hyb21l')).toEqual(true);
       done();
+    }).catch((exception) => {
+      done.fail(exception);
     });
   });
 });


### PR DESCRIPTION
- Fixed intermittent unit test failures for cwc.cache.addFile() that occured
  when the function as called twice in the same session, resulting in an
  exception because an item with the same key was already in the database.

- Modified unit tests that download files from github to timeout after 10
  seconds and set appropriate Jasmine timeout to get appropriate error
  message when timeouts occur.