### PR TITLE
Fixes issue #224: Copied warning message to all Vision Kit tiles

### DIFF
--- a/src/ui/select_screen/advanced/aiy/aiy.soy
+++ b/src/ui/select_screen/advanced/aiy/aiy.soy
@@ -103,6 +103,7 @@
           {call cwc.soy.SelectScreenTemplate.fileCard data="all"}
             {param title: 'Joy Detection' /}
             {param text: 'AIY will tell you when you are smiling' /}
+            {param warning: 'Please note that if you connect to the AIY kit, joydemo will be disabled automatically.' /}
             {param opt_link_text: 'Start Smiling' /}
             {param file: 'aiy/vision/joy/joy_detection_demo.cwc' /}
             {param opt_color_class: 'bg-orange' /}
@@ -111,6 +112,7 @@
           {call cwc.soy.SelectScreenTemplate.fileCard data="all"}
             {param title: 'Image Classification' /}
             {param text: 'AIY will tell you what it sees' /}
+            {param warning: 'Please note that if you connect to the AIY kit, joydemo will be disabled automatically.' /}
             {param opt_link_text: 'Start Classifying' /}
             {param file: 'aiy/vision/image_classification_camera.cwc' /}
             {param opt_color_class: 'bg-orange' /}


### PR DESCRIPTION
Fixes issue #224 

Added the warning message to all tiles under "Vision Kit". 

![image](https://user-images.githubusercontent.com/28423205/67320204-e0520e80-f4db-11e9-891e-f7a63658b7df.png)





