### PR TITLE
Make title editable only for CWC files, set to filename otherwise.

### DIFF
--- a/src/file_handler/file_handler.js
+++ b/src/file_handler/file_handler.js
@@ -220,6 +220,10 @@ cwc.fileHandler.File.prototype.getFileTour = function(language) {
  */
 cwc.fileHandler.File.prototype.setFilename = function(filename) {
   this.filename_ = filename;
+  // Non-CWC files don't have title metadata, so always set to filename.
+  if (!this.file_) {
+    this.setFileTitle(filename);
+  }
 };
 
 

--- a/src/file_handler/file_saver.js
+++ b/src/file_handler/file_saver.js
@@ -174,7 +174,6 @@ cwc.fileHandler.FileSaver.prototype.prepareContent = async function() {
  */
 cwc.fileHandler.FileSaver.prototype.addFileExtension = function(
     filename, extension = cwc.utils.mime.Type.CWC.ext[0]) {
-  console.log('addFileExtension', filename);
   if (!filename) {
     this.log_.error('Invalid filename', filename, 'for', extension);
     return;
@@ -250,6 +249,7 @@ cwc.fileHandler.FileSaver.prototype.fileWriterHandler = function(
     }
     fileInstance.setFileHandler(file_entry);
     fileInstance.setUnsavedChange(false);
+    fileInstance.setFilename(filename);
     helperInstance.showSuccess('Saved file ' + filename + ' successful.');
   };
   writer.onerror = function(opt_event) {

--- a/src/ui/gui/gui.js
+++ b/src/ui/gui/gui.js
@@ -179,6 +179,13 @@ cwc.ui.Gui.prototype.setFullscreen = function(fullscreen = true) {
  * @param {string} title Title to display in the gui.
  */
 cwc.ui.Gui.prototype.setTitle = function(title) {
+  // Disable setting title for non-CWC files.
+  let fileInstance = this.helper.getInstance('file');
+  if (this.nodeTitle && fileInstance && !fileInstance.getFile()) {
+    this.nodeTitle.disabled = true;
+  } else {
+    this.nodeTitle.removeAttribute('disabled');
+  }
   this.showTitle(title);
   if (title && this.nodeTitle && title !== undefined) {
     this.nodeTitle.value = title;


### PR DESCRIPTION
For non-CWC files the title shows up as an editable text field. But this is confusing because it is never saved and has no significance for raw files.  Instead this change makes the title field always be set to the filename for non-CWC file formats and non-editable.