### PR TITLE
Update BlockEditor.js DOM text reinterpreted as HTML

### DIFF
--- a/src/components/BlockEditor/BlockEditor.js
+++ b/src/components/BlockEditor/BlockEditor.js
@@ -646,7 +646,7 @@ export class BlockEditor extends React.PureComponent {
     const textAsBlob = new Blob([this.state.xml], { type: 'text/plain' });
     const downloadLink = document.createElement('a');
     downloadLink.download = `${this.props.project.name}-${this.props.project.id}.xml`;
-    downloadLink.innerHTML = 'Download File';
+    downloadLink.innerText = 'Download File';
     if (window.webkitURL != null) {
       // Chrome allows the link to be clicked without actually adding it to the DOM.
       downloadLink.href = window.webkitURL.createObjectURL(textAsBlob);


### PR DESCRIPTION
By using innerText, it will avoid the risk of HTML injection, as these properties automatically escape any HTML special characters in the provided text. This helps prevent cross-site scripting (XSS) vulnerabilities by treating the input as plain text rather than interpreted HTML.